### PR TITLE
ImageDisk support, 8 and 9 sector/track support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ BUILD_TYPE	?=	debug
 TARGET		=	freebee
 
 # source files that produce object files
-SRC			=	main.c state.c memory.c wd279x.c wd2010.c keyboard.c tc8250.c
+SRC			=	main.c state.c memory.c wd279x.c wd2010.c keyboard.c tc8250.c diskimg.c
 SRC			+=	musashi/m68kcpu.c musashi/m68kdasm.c musashi/m68kops.c musashi/m68kfpu.c
 
 # source type - either "c" or "cpp" (C or C++)

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ BUILD_TYPE	?=	debug
 TARGET		=	freebee
 
 # source files that produce object files
-SRC			=	main.c state.c memory.c wd279x.c wd2010.c keyboard.c tc8250.c diskimg.c
+SRC			=	main.c state.c memory.c wd279x.c wd2010.c keyboard.c tc8250.c diskraw.c diskimd.c
 SRC			+=	musashi/m68kcpu.c musashi/m68kdasm.c musashi/m68kops.c musashi/m68kfpu.c
 
 # source type - either "c" or "cpp" (C or C++)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Phil Pemberton -- <philpem@philpem.me.uk>
 
   - Download the 3B1 ROMs from Bitsavers: [link](http://bitsavers.org/pdf/att/3b1/firmware/3b1_roms.zip)
   - Download the 3B1 Foundation disk set from Bitsavers: [here](http://bitsavers.org/bits/ATT/unixPC/system_software_3.51/)
-    * These will need to be converted from Imagedisk to binary format
     * The disk images on unixpc.org don't work: the boot track is missing.
   - Unzip the ROMs ZIP file and put the ROMs in a directory called `roms`:
     * Rename `14C 72-00616.bin` to `14c.bin`.
@@ -59,9 +58,10 @@ Phil Pemberton -- <philpem@philpem.me.uk>
     * Note that you need the Enhanced Diagnostics disk to format 16-head hard drives.
   - Install the operating system
     * Follow the instructions in the [3B1 Software Installation Guide](http://bitsavers.org/pdf/att/3b1/999-801-025IS_ATT_UNIX_PC_System_Software_Installation_Guide_1987.pdf) to install UNIX.
+    * Copy `01_Diagnostic_Disk_Ver_3.51.IMD` to `discim` in the Freebee directory.
     * To change disks:
       * Press F11 to release the disk image.
-      * Copy the next disk image as "discim" in the Freebee directory.
+      * Copy the next disk image as `discim` in the Freebee directory.
       * Press F11 to load the disk image.
   - After installation has finished (when the login prompt appears):
     * Log in as `root`
@@ -70,13 +70,15 @@ Phil Pemberton -- <philpem@philpem.me.uk>
     * `sed 's/.phinit .modeminit//' rc.old > rc`
     * `reboot`
     * The above commands disable the phone and modem initialisation, which crash due to un-emulated hardware.
+  - Files can be imported using the `msdos` command which allows reading a 360k MS-DOS floppy image.
+    * Use dosbox to copy files to a DOS disk image (`discim`).
 
 
 # Keyboard commands
 
   * F10 -- Grab/Release mouse cursor
-  * F11 -- Load/unload floppy disk
-  * Alt-F12 -- exit
+  * F11 -- Load/Unload floppy disk image
+  * Alt-F12 -- Exit
 
 
 # Useful links

--- a/src/diskimg.c
+++ b/src/diskimg.c
@@ -1,0 +1,211 @@
+#include "diskimg.h"
+
+#define DISKIMG_DEBUG
+
+#ifndef DISKIMG_DEBUG
+#define NDEBUG
+#endif
+#include "utils.h"
+
+int init_raw(struct disk_image *ctx, FILE *fp, int secsz, int heads, int tracks)
+{
+	int spt;
+	size_t filesize;
+	
+	ctx->fp = fp;
+	ctx->secsz = secsz;
+	
+	// Start by finding out how big the image file is
+	fseek(fp, 0, SEEK_END);
+	filesize = ftell(fp);
+	fseek(fp, 0, SEEK_SET);
+	
+	// Calculate sectors per track
+	spt = filesize / secsz / heads / tracks;
+	
+	return spt;
+}
+
+int init_imd(struct disk_image *ctx, FILE *fp, int secsz, int heads, int tracks)
+{
+	uint8_t sdrType, track_sector_map[10], ch;
+    IMD_TRACK_HEADER trackHeader;
+    int spt;
+    size_t filepos;
+    
+	// write out and advance past comments
+    fseek(fp, 0, SEEK_SET);
+	while (1) {
+		ch = fgetc(fp);
+		if (ch == IMD_END_OF_COMMENT || feof(fp))
+		   break;
+		else
+		   printf("%c", ch);
+	}
+	if (feof(fp)) return -1;
+
+	// probe first track header to get spt
+	filepos = ftell(fp);
+	if (!fread(&trackHeader, sizeof(trackHeader), 1, fp))
+	{
+		fprintf(stderr, "error reading IMD track header\n");
+		return -1;
+	}
+	fseek(fp, filepos, SEEK_SET);
+	spt = trackHeader.spt;
+	
+    ctx->fp = fp;
+    ctx->secsz = secsz;
+
+	// allocate sectorMap
+	if (ctx->sectorMap) free(ctx->sectorMap);
+	ctx->sectorMap = malloc(tracks*heads*spt*sizeof(uint32_t));
+	if (!ctx->sectorMap) return -1;
+    	
+	// tracks start, build sector offset map, check for unexpected SDRs
+	for (int track_i=0; track_i < tracks*heads; track_i++)
+	{		
+		if (!fread(&trackHeader, sizeof(trackHeader), 1, fp))
+		{
+			fprintf(stderr, "error reading IMD track header\n");
+			return -1;
+		}
+		// data mode 4 and 5 supported, secsz = 128 << secsz_code, head map & cylinder map flags unsupported
+		if (!(trackHeader.data_mode == 5 || trackHeader.data_mode == 4) || trackHeader.spt != spt ||
+			  trackHeader.secsz_code != 2 || (trackHeader.head & ~IMD_HEAD_MASK))
+		{
+			fprintf(stderr, "unexpected IMD track header data, track %i\n", track_i+1);
+			return -1;
+		}
+		if (!fread(track_sector_map, spt, 1, fp))
+		{
+			fprintf(stderr, "error reading IMD track sector map\n");
+			return -1;
+		}		
+		
+		for (int sect_i=0;  sect_i < spt; sect_i++)
+		{
+			ctx->sectorMap[(track_i*spt) + track_sector_map[sect_i] - 1] = ftell(fp);
+			sdrType = fgetc(fp);
+			switch (sdrType) {
+				case IMD_SDR_DATA:
+					fseek(fp, secsz, SEEK_CUR);	
+					break;
+				case (IMD_SDR_DATA + IMD_SDR_COMPRESSED):
+					fgetc(fp);  // fill byte
+					break;
+				default:
+					fprintf(stderr, "unexpected IMD sector data record: %i\n", sdrType);
+					return -1;
+				}
+		}
+	}
+    LOG("IMD file size: %li", ftell(fp));
+	return spt;
+}
+
+void done_raw(struct disk_image *ctx)
+{
+	ctx->fp = NULL;
+    ctx->secsz = 0;	
+}
+
+void done_imd(struct disk_image *ctx)
+{
+	if (ctx->sectorMap) free(ctx->sectorMap);
+	ctx->sectorMap = NULL;
+	
+	ctx->fp = NULL;
+    ctx->secsz = 0;
+}
+
+size_t read_sector_raw(struct disk_image *ctx, int lba, uint8_t *data)
+{
+	size_t bytes_read;
+	
+	LOG("\tREAD(raw) lba = %i", lba);
+
+	// convert LBA to byte address
+	lba *= ctx->secsz;
+
+	// Read the sector from the file
+	fseek(ctx->fp, lba, SEEK_SET);
+	
+	// TODO: check fread return value! if < secsz, BAIL! (call it a crc error or secnotfound maybe? also log to stderr)
+	bytes_read = fread(data, 1, ctx->secsz, ctx->fp);
+	LOG("\tREAD(raw) len=%lu, ssz=%d", bytes_read, ctx->secsz);
+	return bytes_read;	
+}
+
+size_t read_sector_imd(struct disk_image *ctx, int lba, uint8_t *data)
+{
+	size_t bytes_read;
+	uint8_t sdrType, fill;
+	
+	LOG("\tREAD(IMD), lba: %i, sectorMap offset: %i", lba, ctx->sectorMap[lba]);
+	fseek(ctx->fp, ctx->sectorMap[lba], SEEK_SET);
+	sdrType = fgetc(ctx->fp);
+	switch (sdrType) {
+		case IMD_SDR_DATA:
+			bytes_read = fread(data, 1, ctx->secsz, ctx->fp);
+			LOG("\tREAD(IMD) len=%lu, ssz=%d", bytes_read, ctx->secsz);			
+			break;
+		case (IMD_SDR_DATA + IMD_SDR_COMPRESSED):
+			fill = fgetc(ctx->fp);
+			memset(data, fill, ctx->secsz);
+			bytes_read = ctx->secsz;
+			LOG("\tREAD(IMD, compressed) len=%lu, ssz=%d", bytes_read, ctx->secsz);
+			break;
+		default:
+			fprintf(stderr, "unexpected sector data record: %i\n", sdrType);
+			return -1;
+		}
+	return bytes_read;
+}
+
+void write_sector_raw(struct disk_image *ctx, int lba, uint8_t *data)
+{
+	// convert LBA to byte address
+	lba *= ctx->secsz;
+	
+	fseek(ctx->fp, lba, SEEK_SET);
+	fwrite(data, 1, ctx->secsz, ctx->fp);
+	fflush(ctx->fp);
+}
+
+void write_sector_imd(struct disk_image *ctx, int lba, uint8_t *data)
+{
+	uint8_t sdrType, fill;
+	
+	LOG("IMD write sector, lba: %i, sectorMap offset: %i", lba, ctx->sectorMap[lba]);
+	
+	// IMD writes only supported if sector was uncompressed, or write data is also compressable
+	fseek(ctx->fp, ctx->sectorMap[lba], SEEK_SET);
+	sdrType = fgetc(ctx->fp);
+	switch (sdrType) {
+		case IMD_SDR_DATA:
+			fwrite(data, 1, ctx->secsz, ctx->fp);
+			fflush(ctx->fp);
+			LOG("WRITE(IMD), ssz=%i", ctx->secsz);
+			break;
+		case (IMD_SDR_DATA + IMD_SDR_COMPRESSED):
+			fill = data[0];
+			// confirm write data is all the same
+			for (int i=0; i < ctx->secsz; i++)
+			{
+			    if (data[i] != fill)
+			    {
+					fprintf(stderr, "**unsupported IMD sector write**\n");
+					return;
+				}
+			}
+			fputc(fill, ctx->fp);
+			LOG("WRITE(IMD, compressed), ssz=%i", ctx->secsz);
+			break;
+		default:
+			fprintf(stderr, "**unsupported IMD sector write**\n");
+	}
+}
+
+DISK_IMAGE raw_format = { init_raw, done_raw, read_sector_raw, write_sector_raw, NULL, NULL, 512 };
+DISK_IMAGE imd_format = { init_imd, done_imd, read_sector_imd, write_sector_imd, NULL, NULL, 512 };

--- a/src/diskimg.h
+++ b/src/diskimg.h
@@ -6,47 +6,23 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define IMD_END_OF_COMMENT 0x1A
-#define IMD_HEAD_MASK 0x03
-#define IMD_SDR_DATA 0x01
-#define IMD_SDR_COMPRESSED 0x01
-
 typedef struct disk_image {	
-	int (*init)(struct disk_image *ctx, FILE *fp, int secsz, int heads, int tracks);
-	void (*done)(struct disk_image *ctx);
-	size_t (*read_sector)(struct disk_image *ctx, int lba, uint8_t *data);
-	void (*write_sector)(struct disk_image *ctx, int lba, uint8_t *data);
+	int (*const init)(struct disk_image *ctx, FILE *fp, int secsz, int heads, int tracks);
+	void (*const done)(struct disk_image *ctx);
+	size_t (*const read_sector)(struct disk_image *ctx, int lba, uint8_t *data);
+	void (*const write_sector)(struct disk_image *ctx, int lba, uint8_t *data);
 
-	uint32_t *sectorMap;  		// sector offset map, needed by IMD
 	FILE *fp;
 	int secsz;
-} DISK_IMAGE;
 
-typedef struct
-{
-	uint8_t  data_mode; 		// data mode (5 = 250kbps DD, 4 = 300kbps DD)
-	uint8_t  cyl;  				// cylinder
-	uint8_t  head; 				// head, flags (cylinder map, head map)
-	uint8_t  spt;  				// sectors/track
-	uint8_t  secsz_code;  		// sector size code (secsz = 128 << secsz_code)
-} IMD_TRACK_HEADER;
+	// IMD specific
+	uint32_t *sectorMap;  		// sector offset map
+} DISK_IMAGE;
 
 typedef enum {
 	DISK_IMAGE_RAW,
 	DISK_IMAGE_IMD				// ImageDisk
 } DISK_IMAGE_FORMAT;
-
-// Raw image functions
-int init_raw(struct disk_image *ctx, FILE *fp, int secsz, int heads, int tracks);
-void done_raw(struct disk_image *ctx);
-size_t read_sector_raw(struct disk_image *ctx, int lba, uint8_t *data);
-void write_sector_raw(struct disk_image *ctx, int lba, uint8_t *data);
-
-// IMD image functions
-int init_imd(struct disk_image *ctx, FILE *fp, int secsz, int heads, int tracks);
-void done_imd(struct disk_image *ctx);
-size_t read_sector_imd(struct disk_image *ctx, int lba, uint8_t *data);
-void write_sector_imd(struct disk_image *ctx, int lba, uint8_t *data);
 
 extern DISK_IMAGE raw_format;
 extern DISK_IMAGE imd_format;

--- a/src/diskimg.h
+++ b/src/diskimg.h
@@ -9,11 +9,11 @@
 typedef struct disk_image {	
 	int (*const init)(struct disk_image *ctx, FILE *fp, int secsz, int heads, int tracks);
 	void (*const done)(struct disk_image *ctx);
-	size_t (*const read_sector)(struct disk_image *ctx, int lba, uint8_t *data);
-	void (*const write_sector)(struct disk_image *ctx, int lba, uint8_t *data);
+	size_t (*const read_sector)(struct disk_image *ctx, int cyl, int head, int sect, uint8_t *data);
+	void (*const write_sector)(struct disk_image *ctx, int cyl, int head, int sect, uint8_t *data);
 
 	FILE *fp;
-	int secsz;
+	int secsz, heads, spt;
 
 	// IMD specific
 	uint32_t *sectorMap;  		// sector offset map

--- a/src/diskimg.h
+++ b/src/diskimg.h
@@ -1,0 +1,54 @@
+#ifndef _DISKIMG_H
+#define _DISKIMG_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define IMD_END_OF_COMMENT 0x1A
+#define IMD_HEAD_MASK 0x03
+#define IMD_SDR_DATA 0x01
+#define IMD_SDR_COMPRESSED 0x01
+
+typedef struct disk_image {	
+	int (*init)(struct disk_image *ctx, FILE *fp, int secsz, int heads, int tracks);
+	void (*done)(struct disk_image *ctx);
+	size_t (*read_sector)(struct disk_image *ctx, int lba, uint8_t *data);
+	void (*write_sector)(struct disk_image *ctx, int lba, uint8_t *data);
+
+	uint32_t *sectorMap;  		// sector offset map, needed by IMD
+	FILE *fp;
+	int secsz;
+} DISK_IMAGE;
+
+typedef struct
+{
+	uint8_t  data_mode; 		// data mode (5 = 250kbps DD, 4 = 300kbps DD)
+	uint8_t  cyl;  				// cylinder
+	uint8_t  head; 				// head, flags (cylinder map, head map)
+	uint8_t  spt;  				// sectors/track
+	uint8_t  secsz_code;  		// sector size code (secsz = 128 << secsz_code)
+} IMD_TRACK_HEADER;
+
+typedef enum {
+	DISK_IMAGE_RAW,
+	DISK_IMAGE_IMD				// ImageDisk
+} DISK_IMAGE_FORMAT;
+
+// Raw image functions
+int init_raw(struct disk_image *ctx, FILE *fp, int secsz, int heads, int tracks);
+void done_raw(struct disk_image *ctx);
+size_t read_sector_raw(struct disk_image *ctx, int lba, uint8_t *data);
+void write_sector_raw(struct disk_image *ctx, int lba, uint8_t *data);
+
+// IMD image functions
+int init_imd(struct disk_image *ctx, FILE *fp, int secsz, int heads, int tracks);
+void done_imd(struct disk_image *ctx);
+size_t read_sector_imd(struct disk_image *ctx, int lba, uint8_t *data);
+void write_sector_imd(struct disk_image *ctx, int lba, uint8_t *data);
+
+extern DISK_IMAGE raw_format;
+extern DISK_IMAGE imd_format;
+
+#endif

--- a/src/diskraw.c
+++ b/src/diskraw.c
@@ -1,0 +1,71 @@
+#include "diskimg.h"
+
+#define DISKRAW_DEBUG
+
+#ifndef DISKRAW_DEBUG
+#define NDEBUG
+#endif
+#include "utils.h"
+
+static int init_raw(struct disk_image *ctx, FILE *fp, int secsz, int heads, int tracks)
+{
+	int spt;
+	size_t filesize;
+	
+	ctx->fp = fp;
+	ctx->secsz = secsz;
+	
+	// Start by finding out how big the image file is
+	fseek(fp, 0, SEEK_END);
+	filesize = ftell(fp);
+	fseek(fp, 0, SEEK_SET);
+	
+	// Calculate sectors per track
+	spt = filesize / secsz / heads / tracks;
+	
+	return spt;
+}
+
+static void done_raw(struct disk_image *ctx)
+{
+	ctx->fp = NULL;
+    ctx->secsz = 0;	
+}
+
+static size_t read_sector_raw(struct disk_image *ctx, int lba, uint8_t *data)
+{
+	size_t bytes_read;
+	
+	LOG("\tREAD(raw) lba = %i", lba);
+
+	// convert LBA to byte address
+	lba *= ctx->secsz;
+
+	// Read the sector from the file
+	fseek(ctx->fp, lba, SEEK_SET);
+	
+	// TODO: check fread return value! if < secsz, BAIL! (call it a crc error or secnotfound maybe? also log to stderr)
+	bytes_read = fread(data, 1, ctx->secsz, ctx->fp);
+	LOG("\tREAD(raw) len=%lu, ssz=%d", bytes_read, ctx->secsz);
+	return bytes_read;	
+}
+
+static void write_sector_raw(struct disk_image *ctx, int lba, uint8_t *data)
+{
+	// convert LBA to byte address
+	lba *= ctx->secsz;
+	
+	fseek(ctx->fp, lba, SEEK_SET);
+	fwrite(data, 1, ctx->secsz, ctx->fp);
+	fflush(ctx->fp);
+}
+
+DISK_IMAGE raw_format = {
+	.init = init_raw,
+	.done = done_raw,
+	.read_sector = read_sector_raw,
+	.write_sector = write_sector_raw,
+	.fp = NULL,
+	.secsz = 512,
+	.sectorMap = NULL
+};

--- a/src/main.c
+++ b/src/main.c
@@ -34,8 +34,7 @@ static int load_fd()
 		state.fdc_disc = NULL;
 		return (0);
 	}else{
-		wd2797_load(&state.fdc_ctx, state.fdc_disc, 512, 10, 2, writeable);
-		fprintf(stderr, "Disc image loaded.\n");
+		wd2797_load(&state.fdc_ctx, state.fdc_disc, 512, 2, 40, writeable);
 		return (1);
 	}
 }
@@ -50,7 +49,7 @@ static int load_hd()
 		return (0);
 	}else{
 		wd2010_init(&state.hdc_ctx, state.hdc_disc0, 512, 16, 8);
-		fprintf(stderr, "Disc image loaded.\n");
+		printf("Disc image loaded.\n");
 		return (1);
 	}
 }
@@ -190,7 +189,7 @@ bool HandleSDLEvents(SDL_Surface *screen)
 							wd2797_unload(&state.fdc_ctx);
 							fclose(state.fdc_disc);
 							state.fdc_disc = NULL;
-							fprintf(stderr, "Disc image unloaded.\n");
+							printf("Floppy image unloaded.\n");
 						} else {
 							load_fd();
 						}
@@ -267,7 +266,7 @@ int main(int argc, char *argv[])
 
 	// Set up SDL
 	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) == -1) {
-		printf("Could not initialise SDL: %s.\n", SDL_GetError());
+		fprintf(stderr, "Could not initialise SDL: %s.\n", SDL_GetError());
 		exit(EXIT_FAILURE);
 	}
 
@@ -277,7 +276,7 @@ int main(int argc, char *argv[])
 	// Set up the video display
 	SDL_Surface *screen = NULL;
 	if ((screen = SDL_SetVideoMode(720, 348, 8, SDL_SWSURFACE | SDL_ANYFORMAT)) == NULL) {
-		printf("Could not find a suitable video mode: %s.\n", SDL_GetError());
+		fprintf(stderr, "Could not find a suitable video mode: %s.\n", SDL_GetError());
 		exit(EXIT_FAILURE);
 	}
 	printf("Set %dx%d at %d bits-per-pixel mode\n\n", screen->w, screen->h, screen->format->BitsPerPixel);
@@ -290,7 +289,7 @@ int main(int argc, char *argv[])
 
 	/***
 	 * The 3B1 CPU runs at 10MHz, with DMA running at 1MHz and video refreshing at
-	 * around 60Hz (???), with a 60Hz periodic interrupt.
+	 * 60.821331Hz, with a 60Hz periodic interrupt.
 	 */
 	const uint32_t SYSTEM_CLOCK = 10e6; // Hz
 	const uint32_t TIMESLOT_FREQUENCY = 100;//240;	// Hz
@@ -332,7 +331,7 @@ int main(int argc, char *argv[])
 							break;
 						}
 					}else{
-						printf("ERROR: DMA attempt with no drive selected!\n");
+						fprintf(stderr, "ERROR: DMA attempt with no drive selected!\n");
 					}
 					if (!access_check_dma(state.dma_reading)) {
 						break;

--- a/src/wd2010.c
+++ b/src/wd2010.c
@@ -5,7 +5,7 @@
 #include "musashi/m68k.h"
 #include "wd2010.h"
 
-#define WD2010_DEBUG
+//#define WD2010_DEBUG
 
 #ifndef WD2010_DEBUG
 #define NDEBUG

--- a/src/wd279x.h
+++ b/src/wd279x.h
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "diskimg.h"
 
 /// WD279x registers
 typedef enum {
@@ -50,6 +51,8 @@ typedef struct {
 	int						write_pos;
 	// True if a format command is in progress
 	int						formatting;
+	// Disc image format i/o
+	DISK_IMAGE				*dif;
 } WD2797_CTX;
 
 /**
@@ -92,11 +95,11 @@ bool wd2797_get_drq(WD2797_CTX *ctx);
  * @param	ctx		WD2797 context.
  * @param	fp		Disc image file, already opened in "r+b" mode.
  * @param	secsz	Sector size: either 128, 256, 512 or 1024.
- * @param	spt		Sectors per track.
  * @param	heads	Number of heads (1 or 2).
+ * @param	tracks	Number of tracks (40).
  * @return	Error code; WD279X_E_OK if everything worked OK.
  */
-WD2797_ERR wd2797_load(WD2797_CTX *ctx, FILE *fp, int secsz, int spt, int heads, int writeable);
+WD2797_ERR wd2797_load(WD2797_CTX *ctx, FILE *fp, int secsz, int heads, int tracks, int writeable);
 
 /**
  * @brief	Deassign the current image file.


### PR DESCRIPTION
Hey Phil. I wanted to get basic ImageDisk support added to make it easier for new users to be able to install the OS without having to use IMDU. I also wanted to support MS-DOS images (9 sectors/track) as a means to getting files into the system. In my testing I also uncovered some IMD's (e.g. personal calendar, electronic mail, communications patch) that were encoded with 8 sectors/track that wouldn't have worked as raw images as the assumption is 10 sectors/track.

I tried to follow your requested direction on how to make the virtual function image formats -- I doubt it's exactly what you had in mind but seems to get the job done. I had to refactor the floppy image loading to get rid of the 10 sect/track assumption, and derive the spt from the disk image. Tracks is now specified at 40. (instead of specifying spt)

I tested this using most of the IMD's I could find on bitsaver. Along with a 360k MS-DOS disk image I wrote to using dosbox. And continued testing with the original RAW versions of images.

Sector read/write was refactored to call the disk image format read_sector and write_sector functions with an LBA.

ImageDisk write support is limited -- but during installs, only lba 0 and lba 1 are written to so should be fine for installation purposes.