### PR TITLE
SDL dev package to SDL2, clarify submodules cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Phil Pemberton -- <philpem@philpem.me.uk>
 
 # Build instructions
 
-  - Install the `libsdl1.2-dev` package
+  - Install the `libsdl2-dev` package
   - Clone a copy of Freebee (remember to check out the submodules too)
+    - `git clone --recurse-submodules https://github.com/philpem/freebee`
   - Build Freebee (run 'make')
 
 


### PR DESCRIPTION
forgot to update the build docs package to libsdl2-dev

also added submodules clone command as this initially tripped me up when trying to build