### PR TITLE
MCR2 bit mirroring, more logging in memory.c

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -26,6 +26,7 @@ int state_init(size_t base_ram_size, size_t exp_ram_size)
 	state.bsr0 = state.bsr1 = 0;	// FIXME: check this
 	state.timer_enabled = state.timer_asserted = false;
 	state.dma_dev = DMA_DEV_UNDEF;
+	state.mcr2mirror = 0;
 	
 	// Enable VIDPAL mod (allows user writing to VRAM)
 	state.vidpal = true;

--- a/src/state.h
+++ b/src/state.h
@@ -107,6 +107,9 @@ typedef struct {
 
 	/// Update screen only when VRAM has been changed
 	bool vram_updated;
+
+	/// MCR2 mirror bit for P5.1 hardware detection
+	bool mcr2mirror;
 } S_state;
 
 // Global emulator state. Yes, I know global variables are evil, please don't

--- a/src/wd2010.c
+++ b/src/wd2010.c
@@ -74,7 +74,11 @@ int wd2010_init(WD2010_CTX *ctx, FILE *fp, int secsz, int spt, int heads)
 	// Now figure out how many tracks it contains
 	unsigned int tracks = filesize / secsz / spt / heads;
 	// Confirm...
-	if (tracks < 1) {
+	if (tracks < 1 || tracks > 1400) {
+		fprintf(stderr, "ERROR loading disc image 'hd.img'.\n");
+		if (tracks > 1400) {
+			fprintf(stderr, "ERROR hard disk cylinders > 1400 unsupported by UNIX.\n");
+		}
 		return WD2010_ERR_BAD_GEOM;
 	}
 


### PR DESCRIPTION
Hey Phil, I added some more logging to memory.c to get a better understanding of what's happening behind the scenes with some of the unsupported writes (like dialer, modem, 8274).  Also cut out a little code that should never be called -- like when it's write only or read only register.  And also a note if cylinders is ever > 1400 which would be unsupported by the OS.