### PR TITLE
P5.1 detection!

### DIFF
--- a/src/diskimd.c
+++ b/src/diskimd.c
@@ -1,6 +1,6 @@
 #include "diskimg.h"
 
-#define DISKIMD_DEBUG
+//#define DISKIMD_DEBUG
 
 #ifndef DISKIMD_DEBUG
 #define NDEBUG

--- a/src/diskraw.c
+++ b/src/diskraw.c
@@ -1,6 +1,6 @@
 #include "diskimg.h"
 
-#define DISKRAW_DEBUG
+//#define DISKRAW_DEBUG
 
 #ifndef DISKRAW_DEBUG
 #define NDEBUG

--- a/src/wd2010.c
+++ b/src/wd2010.c
@@ -82,7 +82,7 @@ int wd2010_init(WD2010_CTX *ctx, FILE *fp, int secsz, int spt, int heads)
 		return WD2010_ERR_BAD_GEOM;
 	}
 
-	LOG("WD2010 initialised, %d cylinders, %d heads, %d sectors per track", tracks, heads, spt);
+	printf("WD2010 initialised: %d cylinders, %d heads, %d sectors per track\n", tracks, heads, spt);
 
 	// Allocate enough memory to store one disc track
 	if (ctx->data) {


### PR DESCRIPTION
Hey Phil. I think I finally figured it out. The 8-bit read of genstat (used in the startup P3 revlev detection) was causing some issues. I shifted the data down 8 bits on an 8-bit read and seems to work properly now. Thanks for digging into the source and finding the revlev mystery solution!