### PR TITLE
fix for malloc in wd2010_init, few other misc things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ src/version.h
 freebee
 3b1emu
 
+# tools
+makehdimg
+
 # ignore ROMs and techref
 roms
 TRM

--- a/src/wd2010.h
+++ b/src/wd2010.h
@@ -33,7 +33,7 @@ typedef struct {
 	int						track, head, sector;
 	// Geometry of current disc
 	struct geom {
-		int	geom_secsz, geom_spt, geom_heads, geom_tracks;
+		int	secsz, spt, heads, tracks;
 	} geometry[2];
 	// IRQ status
 	bool					irq;


### PR DESCRIPTION
Hey @philpem and @arnoldrobbins 

I wanted to get that malloc fix in `wd2010_init()` checked in so we don't forget about it. Hopefully addresses Issue #30.  I also changed the naming on the geom variables so they are a little less overwhelming when reading the code since they are now in their own `geometry` struct.

The changes to memory.c are mostly cosmetic/cleanup, but I wanted to get them checked in before i do my i8274 serial port checkin.  Hope to have that soon. It's working and you can login via a PTY under linux. I was even able to get `cu` to work and  "get out" of the system connecting to my linux machine, and then telneting from there. It's been fun :)

   Jesse