### PR TITLE
a couple misc updates, including different foreground color

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -137,8 +137,8 @@ void refreshScreen(SDL_Surface *s, SDL_Renderer *r, SDL_Texture *t)
 	// Map the foreground and background colours
 //	Uint32 fg = SDL_MapRGB(s->format, 0xFF, 0xC1, 0x06);	// amber foreground
 //	Uint32 fg = SDL_MapRGB(s->format, 0xFF, 0xFF, 0xFF);	// white foreground
-//	Uint32 fg = SDL_MapRGB(s->format, 0x00, 0xFF, 0x00);	// green foreground
-	Uint32 fg = SDL_MapRGB(s->format, 0x50, 0xFF, 2*0x50);	// minty foreground (rough approximation for 3b1 screen: Blue = 2*Red)
+//	Uint32 fg = SDL_MapRGB(s->format, 0x50, 0xFF, 0xA0);	// minty foreground (possibly closer to actual color?)
+	Uint32 fg = SDL_MapRGB(s->format, 0x00, 0xFF, 0x00);	// green foreground
 	Uint32 bg = SDL_MapRGB(s->format, 0x00, 0x00, 0x00);	// black background
 
 	// Refresh the 3B1 screen area first. TODO: only do this if VRAM has actually changed!

--- a/src/main.c
+++ b/src/main.c
@@ -135,9 +135,10 @@ void refreshScreen(SDL_Surface *s, SDL_Renderer *r, SDL_Texture *t)
 	}
 
 	// Map the foreground and background colours
-	Uint32 fg = SDL_MapRGB(s->format, 0x00, 0xFF, 0x00);	// green foreground
 //	Uint32 fg = SDL_MapRGB(s->format, 0xFF, 0xC1, 0x06);	// amber foreground
 //	Uint32 fg = SDL_MapRGB(s->format, 0xFF, 0xFF, 0xFF);	// white foreground
+//	Uint32 fg = SDL_MapRGB(s->format, 0x00, 0xFF, 0x00);	// green foreground
+	Uint32 fg = SDL_MapRGB(s->format, 0x50, 0xFF, 2*0x50);	// minty foreground (rough approximation for 3b1 screen: Blue = 2*Red)
 	Uint32 bg = SDL_MapRGB(s->format, 0x00, 0x00, 0x00);	// black background
 
 	// Refresh the 3B1 screen area first. TODO: only do this if VRAM has actually changed!
@@ -373,7 +374,7 @@ int main(int argc, char *argv[])
 	SDL_Texture *lightbarTexture = SDL_CreateTextureFromSurface(renderer, surf);
 	SDL_FreeSurface(surf);
 
-	printf("Set %dx%d at %d bits-per-pixel mode\n\n", screen->w, screen->h, screen->format->BitsPerPixel);
+	printf("Set %dx%d at %d bits-per-pixel mode\n\n", (int) ceilf(720*scalex), (int) ceilf(348*scaley), screen->format->BitsPerPixel);
 
 	// Load a disc image
 	load_fd();
@@ -412,7 +413,7 @@ int main(int argc, char *argv[])
 
 					// num tells us how many words we've copied. If this is greater than the per-timeslot DMA maximum, bail out!
 					if (num > (1e6/TIMESLOT_FREQUENCY)) break;
-	
+
 					// Evidently we have more words to copy. Copy them.
 					if (state.dma_dev == DMA_DEV_FD){
 						if (!wd2797_get_drq(&state.fdc_ctx)) {
@@ -433,7 +434,7 @@ int main(int argc, char *argv[])
 					uint32_t newAddr;
 					// Map logical address to a physical RAM address
 					newAddr = mapAddr(state.dma_address, !state.dma_reading);
-	
+
 					if (!state.dma_reading) {
 						// Data available. Get it from the FDC or HDC.
 						if (state.dma_dev == DMA_DEV_FD) {
@@ -462,7 +463,7 @@ int main(int argc, char *argv[])
 							else
 								d = 0xffff;
 						}
-	
+
 						// Send the data to the FDD or HDD
 						if (state.dma_dev == DMA_DEV_FD){
 							wd2797_write_reg(&state.fdc_ctx, WD2797_REG_DATA, (d >> 8));

--- a/src/tc8250.c
+++ b/src/tc8250.c
@@ -41,7 +41,7 @@ uint8_t get_second(TC8250_CTX *ctx)
 	struct tm g;
 	uint8_t ret;
 	t = time(NULL);
-	gmtime_r(&t, &g);
+	localtime_r(&t, &g);
 	ret = g.tm_sec;
 	return (ret);
 }
@@ -52,7 +52,7 @@ uint8_t get_minute(TC8250_CTX *ctx)
 	struct tm g;
 	uint8_t ret;
 	t = time(NULL);
-	gmtime_r(&t, &g);
+	localtime_r(&t, &g);
 	ret = g.tm_min;
 	return (ret);
 }
@@ -63,7 +63,7 @@ uint8_t get_hour(TC8250_CTX *ctx)
 	struct tm g;
 	uint8_t ret;
 	t = time(NULL);
-	gmtime_r(&t, &g);
+	localtime_r(&t, &g);
 	ret = g.tm_hour;
 	return (ret);
 }
@@ -74,7 +74,7 @@ uint8_t get_day(TC8250_CTX *ctx)
 	struct tm g;
 	uint8_t ret;
 	t = time(NULL);
-	gmtime_r(&t, &g);
+	localtime_r(&t, &g);
 	ret = g.tm_mday;
 	return (ret);
 }
@@ -85,7 +85,7 @@ uint8_t get_month(TC8250_CTX *ctx)
 	struct tm g;
 	uint8_t ret;
 	t = time(NULL);
-	gmtime_r(&t, &g);
+	localtime_r(&t, &g);
 	ret = g.tm_mon+1;
 	return (ret);
 }
@@ -96,7 +96,7 @@ uint8_t get_year(TC8250_CTX *ctx)
 	struct tm g;
 	uint8_t ret;
 	t = time(NULL);
-	gmtime_r(&t, &g);
+	localtime_r(&t, &g);
 	ret = g.tm_year;
 	return (ret);*/
 	return (87);
@@ -108,7 +108,7 @@ uint8_t get_weekday(TC8250_CTX *ctx)
 	struct tm g;
 	uint8_t ret;
 	t = time(NULL);
-	gmtime_r(&t, &g);
+	localtime_r(&t, &g);
 	ret = g.tm_wday;
 	return (ret);
 }

--- a/src/tc8250.c
+++ b/src/tc8250.c
@@ -142,7 +142,7 @@ uint8_t tc8250_read_reg(TC8250_CTX *ctx)
 		case TEN_YR_DIGT:
 			return (get_year(ctx) / 10);
 		case WEEK_DAY:
-			return (get_weekday(ctx) / 10);
+			return (get_weekday(ctx));
 		case TOUT_CONTROL:
 			return (0);
 		case PROTECT_KEY:


### PR DESCRIPTION
Hey @philpem and @arnoldrobbins -- I updated the foreground color to try to be more like the original monitor color after looking at various 3b1 monitor photos -- I hope you don't hate it. If not, let me know and we can go with whatever default you want to. I also updated the print statement on boot to reflect the window size (so you can validate what window size is being used when using the -s scaling option).

I was looking into the expansion slots for fun the other day so put a few notes in on those. 

Also realized that sending 0xFF when queried about the modem will be interpreted as "no modem" which I was hoping might help with the .phinit hang on installation but alas it did not.

And final fix was to the logging of the baud rate setting for rs232 -- not material, but I did start getting more activity on that log entry when messing with the serial port so figured I would correct it.  e.g. if you do 'stty 1200', 'stty 300', 'stty 9600', etc when logged in through the serial port, you'll see calls with the respective speeds to that baud gen write.