### PR TITLE
Redefining MAKE in Makefile defeats the purpose of MAKE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,6 @@ endif
 ####
 # Tool setup
 ####
-MAKE	=	make
 CC		=	gcc
 CXX		=	g++
 CFLAGS	=	-O -Wall -pedantic -std=gnu99 $(EXT_CFLAGS)


### PR DESCRIPTION
MAKE variable is predefined by GNU Make as the command name of invoking **make(1)** program; this is useful when GNU Make is installed with an alternative name, such as `gmake` on FreeBSD system.

Since the freebee Makefile uses GNU-specific features, it won't work on other **make(1)** implementations, including BSD make, the default **make(1)** on FreeBSD.

Redefining this variable makes it unable to build on such environment, even the user aware that it requires GNU Make, and runs `gmake` on first place, the Makefile will still running `make` (BSD make) instead, resulting build failure.