### PR TITLE
Update serial support in config and man page, fix shutdown.

### DIFF
--- a/freebee.1
+++ b/freebee.1
@@ -1,4 +1,4 @@
-.TH FREEBEE 1 "Feb 5 2021" "" "AT&T 3B1 Emulation"
+.TH FREEBEE 1 "Feb 10 2021" "" "AT&T 3B1 Emulation"
 .SH NAME
 freebee \- emulate an AT&T 3B1 personal computer
 .SH SYNOPSIS
@@ -101,12 +101,22 @@ create and install such a disk from scratch.
 An optional image for the second hard disk.
 This disk is not mounted when the system boots; you can use it
 for whatever you want.
+.TP
+.I serial-pty
+A symbolic link to the pseudo-terminal file
+.RI ( /dev/pts/? )
+which can be used to connect to the 3B1's serial port for user login to
+the 3B1, dial-out from it,
+or for file transfer. See the file
+.I README.serial.md
+in the source code directory for more information and concise
+instructions on how to use the serial port.
 .SH AUTHORS
 Phil Pemberton, with contributions from several others.
 .SH BUG REPORTS
 Please open an issue on the Github project,
 \f(CWhttps://github.com/philpem/freebee\fP.
 .SH BUGS
-The original 3B1 serial port(s) and modem are not emulated.
+The original 3B1 modem is not emulated.
 .PP
 To avoid Y2K bugs in the OS, the year in the running system is always 1987.

--- a/sample.freebee.toml
+++ b/sample.freebee.toml
@@ -21,3 +21,6 @@
 [roms]
 	rom_14c = "/path/to/roms/14c.bin"	# Odd locations
 	rom_15c = "/path/to/roms/15c.bin"	# Even locations
+
+[serial]
+	symlink = "serial-pty"

--- a/src/fbconfig.c
+++ b/src/fbconfig.c
@@ -65,6 +65,7 @@ get_default_string(const char *heading, const char *item)
 		{ "hard_disk", "disk2", "hd2.img" },
 		{ "roms", "rom_14c", "roms/14c.bin" },
 		{ "roms", "rom_15c", "roms/15c.bin" },
+		{ "serial", "symlink", "serial-pty" },
 		{ NULL, NULL, NULL }
 	};
 

--- a/src/main.c
+++ b/src/main.c
@@ -587,8 +587,11 @@ int main(int argc, char *argv[])
 	SDL_DestroyTexture(lightbarTexture);
 	SDL_FreeSurface(screen);
 	SDL_DestroyTexture(fbTexture);
-    SDL_DestroyRenderer(renderer);
-    SDL_DestroyWindow(window);
+	SDL_DestroyRenderer(renderer);
+	SDL_DestroyWindow(window);
+
+    	// clean up all hardware state
+	state_done();
 
 	return 0;
 }


### PR DESCRIPTION
Document the `serial-pty` file.  Update the config to support this as well.
Fix shutdown to reset all the state. This is particularly needed to unlink the serial-pty file.