### PR TITLE
misc cleanup, pre-loaded images to README, 16 -> 17 sec/trk  

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Phil Pemberton -- <philpem@philpem.me.uk>
     * Two separate drives.
     * Maximum 1400 cylinders (limited by the UNIX OS, see [the UNIX PC FAQ, section 5.6](http://www.unixpc.org/FAQ)).
     * Heads fixed at 8.
-    * Sectors per track fixed at 16.
+    * Sectors per track fixed at 17.
     * Fixed 512 bytes per sector.
     * Those numbers are the default configuration; see below for more information.
   * WD2797 floppy disk controller.
@@ -51,43 +51,55 @@ Phil Pemberton -- <philpem@philpem.me.uk>
 
 # Running Freebee
 
+## Initial Setup
   - Download the 3B1 ROMs from Bitsavers: [link](http://bitsavers.org/pdf/att/3b1/firmware/3b1_roms.zip)
+  - Unzip the ROMs ZIP file and put the ROMs in a directory called `roms`:
+    * Rename `14C 72-00616.bin` to `14c.bin`
+    * Rename `15C 72-00617.bin` to `15c.bin`
+
+## Option 1: Use an existing drive image
+  - Arnold Robbins created a drive image installed with all sorts of tools: [here](https://www.skeeve.com/3b1/)
+  - David Gesswein created a drive image for the VCF Museum: [here](http://www.pdp8online.com/3b1/demos.shtml)
+  - Uncompress either of these images in the Freebee directory and rename the image to `hd.img`
+
+## Option 2: Do a fresh install
   - Download the 3B1 Foundation disk set from Bitsavers: [here](http://bitsavers.org/bits/ATT/unixPC/system_software_3.51/)
     * The disk images on unixpc.org don't work: the boot track is missing.
     * Use the replacement version of the `08_Foundation_Set_Ver_3.51.IMD` image which is available [here](https://www.skeeve.com/3b1/os-install/index.html).
-  - Unzip the ROMs ZIP file and put the ROMs in a directory called `roms`:
-    * Rename `14C 72-00616.bin` to `14c.bin`.
-    * Rename `15C 72-00617.bin` to `15c.bin`.
   - Create a hard drive image file:
     * Use the `makehdimg` program supplied in the `tools` directory to create an initial `hd.img` file with the number of cylinders, heads and sectors per track that you want.  Limits: 1400 cylinders, 16 heads, 17 sectors per track.
     * When using the diagnostics disk to initialize the hard disk, select "Other" and supply the correct values that correspond to the numbers used with `makehdimg`.
-    * You can use `dd if=/dev/zero of=hd.img bs=512 count=$(expr 17 \* 8 \* 1024)` to create a disk matching the compiled-in defaults.  You still need to initialize the disk using the "Miniscribe 64MB" (CHS 1024:8:17, 512 bytes per sector) choice.
+    * Alternatively, you can use `dd if=/dev/zero of=hd.img bs=512 count=$(expr 17 \* 8 \* 1024)` to create a disk matching the compiled-in defaults. Initialize the disk using the "Miniscribe 64MB" (CHS 1024:8:17, 512 bytes per sector) choice.
     * The second hard drive file is optional. If present, it should be called `hd2.img`.  You can copy an existing `hd.img` to `hd2.img` as a quick way to get a disk with a filesystem already on it. When Unix is up and running, use `mount /dev/fp012 /mnt` to mount the second drive. You may want to run `fsck` on it first, just to be safe.
   - You can also use the ICUS Enhanced Diagnostics disk. A bootable copy is
   available [here](https://www.skeeve.com/3b1/enhanced-diag/index.html).
   Uncompress it before using.
   - Install the operating system:
     * Follow the instructions in the [3B1 Software Installation Guide](http://bitsavers.org/pdf/att/3b1/999-801-025IS_ATT_UNIX_PC_System_Software_Installation_Guide_1987.pdf) to install UNIX.
-    * Copy `01_Diagnostic_Disk_Ver_3.51.IMD` to `discim` in the Freebee directory.
+    * Copy `01_Diagnostic_Disk_Ver_3.51.IMD` to `floppy.img` in the Freebee directory.
     * If you wish to increase the swap space size, do so with the diagnostics
       disk before installing the OS. See these [instructions](https://groups.google.com/g/comp.sys.att/c/8XLILI3K8-Y/m/VxVMJNdt9NQJ).
     * To change disks:
       * Press F11 to release the disk image.
-      * Copy the next disk image as `discim` in the Freebee directory.
+      * Copy the next disk image to `floppy.img` in the Freebee directory.
       * Press F11 to load the disk image.
     * Instead of `08_Foundation_Set_Ver_3.51.IMD` use `08_Foundation_Set_Ver_3.51_no_phinit.IMD` from [here](https://www.skeeve.com/3b1/os-install/index.html).
       This will allow the emulated Unix PC to come all the way up to
       a login prompt after the installation.
-  - Files can be imported using the `msdos` command which allows reading a 360k MS-DOS floppy image.
-    * Use dosbox to copy files to a DOS disk image (`discim`).
-  - Another option is to use the tools [here](https://github.com/dgesswein/s4-3b1-pc7300) which allow you to export the file system image out of the disk image and import the image back. In particular, there is an updated `sysv` Linux kernel module which allows mounting the image as a usable filesystem under Linux.
+
+## Importing files
+  - Files can be imported using the 3b1 `msdos` command which allows reading a 360k MS-DOS floppy image.
+    * Use dosbox to copy files to a DOS disk image named `floppy.img`. This image must be in the same directory as the Freebee executable (or path specified in the .freebee.toml config file).
+    * If the floppy.img file wasn't present on boot or was updated, hit F11 to load/unload the floppy image.
+    * Run `msdos` from the 3b1 command prompt, grab the mouse cursor with F10 if you haven't already, then COPY files to the hard drive.
+  - Another option is to use the s4tools [here](https://github.com/dgesswein/s4-3b1-pc7300) which allow you to export the file system image out of the disk image and import the fs image back. In particular, there is an updated `sysv` Linux kernel module which allows mounting the fs image as a usable filesystem under Linux.
 
 
 # Keyboard commands
 
   * F9 -- Send the SUSPEND key
   * F10 -- Grab/Release mouse cursor
-  * F11 -- Load/Unload floppy disk image
+  * F11 -- Load/Unload floppy disk image (`floppy.img`)
   * Alt-F12 -- Exit
 
 

--- a/freebee.1
+++ b/freebee.1
@@ -34,7 +34,7 @@ some in binary form, from archives that are also linked to from
 home page.
 .PP
 The system more-or-less represents the state of the art in the
-Unix world as of about 1987.  The Unix PC and 3B1 were the first
+Unix world as of about 1985.  The Unix PC and 3B1 were the first
 .I personal
 Unix systems that were affordable by individuals, as opposed to higher-end
 workstations from companies like Sun, DEC, IBM, Tektronix, and Silicon Graphics.
@@ -86,7 +86,7 @@ The ROM image files. Links to them are provided on the
 .I freebee
 home page.
 .TP
-.I discim
+.I floppy.img
 An optional image of a floppy disk.  By default,
 .I freebee
 attaches this file when it starts up. Use F11 to unload and

--- a/sample.freebee.toml
+++ b/sample.freebee.toml
@@ -8,8 +8,8 @@
 	disk = "/path/to/floppy.img"	# Floppy disk is optional
 
 [hard_disk]
-	disk1 = "/path/to/disk1.img"
-	disk2 = "/path/to/disk2.img"	# Second disk is optional
+	disk1 = "/path/to/hd.img"
+	disk2 = "/path/to/hd2.img"	# Second disk is optional
 
 [display]
 	x_scale = 1.0			# How much to scale in X dimension

--- a/src/fbconfig.c
+++ b/src/fbconfig.c
@@ -60,7 +60,7 @@ get_default_string(const char *heading, const char *item)
 		const char *item;
 		const char *value;
 	} defaults[] = {
-		{ "floppy", "disk", "discim" },
+		{ "floppy", "disk", "floppy.img" },
 		{ "hard_disk", "disk1", "hd.img" },
 		{ "hard_disk", "disk2", "hd2.img" },
 		{ "roms", "rom_14c", "roms/14c.bin" },

--- a/src/main.c
+++ b/src/main.c
@@ -37,7 +37,7 @@ static int load_fd()
 		state.fdc_disc = fopen(discim, "rb");
 	}
 	if (!state.fdc_disc){
-		fprintf(stderr, "ERROR loading disc image 'discim'.\n");
+		fprintf(stderr, "ERROR loading floppy image '%s'.\n", discim);
 		state.fdc_disc = NULL;
 		return (0);
 	}else{
@@ -54,25 +54,31 @@ static int load_hd()
 
 	state.hdc_disc0 = fopen(disk1, "r+b");
 	if (!state.hdc_disc0){
-		fprintf(stderr, "ERROR loading disc image '%s'.\n", disk1);
+		fprintf(stderr, "Drive 0: ERROR loading disc image '%s'.\n", disk1);
 		state.hdc_disc0 = NULL;
 		return (0);
 	} else {
-		wd2010_init(&state.hdc_ctx, state.hdc_disc0, 0, 512, 16, 8);
-		printf("Disc image '%s' loaded.\n", disk1);
-		ret = 1;
+		if (wd2010_init(&state.hdc_ctx, state.hdc_disc0, 0, 512, 17, 8) == WD2010_ERR_OK) {
+			printf("Drive 0: Disc image '%s' loaded.\n", disk1);
+			ret = 1;
+		} else {
+			fprintf(stderr, "Drive 0: ERROR loading disc image '%s'.\n", disk1);
+			ret = 0;
+		}
 	}
 
 	state.hdc_disc1 = fopen(disk2, "r+b");
 	if (!state.hdc_disc1){
-		fprintf(stderr, "ERROR loading disc image '%s'.\n", disk2);
+		fprintf(stderr, "Drive 1: ERROR loading disc image '%s'.\n", disk2);
 		state.hdc_disc1 = NULL;
-		return ret;
 	} else {
-		wd2010_init(&state.hdc_ctx, state.hdc_disc1, 1, 512, 16, 8);
-		printf("Disc image '%s' loaded.\n", disk2);
-		return (1);
+		if (wd2010_init(&state.hdc_ctx, state.hdc_disc1, 1, 512, 17, 8) == WD2010_ERR_OK) {
+			printf("Drive 1: Disc image '%s' loaded.\n", disk2);
+		} else {
+			fprintf(stderr, "Drive 1: ERROR loading disc image '%s'.\n", disk2);
+		}
 	}
+	return ret;
 }
 
 

--- a/src/wd2010.c
+++ b/src/wd2010.c
@@ -80,9 +80,8 @@ static int wd2010_default_init(WD2010_CTX *ctx, FILE *fp, int drivenum, int secs
 	unsigned int tracks = filesize / secsz / spt / heads;
 	// Confirm...
 	if (tracks < 1 || tracks > 1400) {
-		fprintf(stderr, "ERROR loading disc image 'hd.img'.\n");
 		if (tracks > 1400) {
-			fprintf(stderr, "ERROR hard disk cylinders > 1400 unsupported by UNIX.\n");
+			fprintf(stderr, "ERROR hard disk %d: cylinders > 1400 unsupported by UNIX.\n", drivenum);
 		}
 		return WD2010_ERR_BAD_GEOM;
 	}
@@ -188,8 +187,10 @@ int wd2010_init(WD2010_CTX *ctx, FILE *fp, int drivenum, int secsz, int spt, int
 		result = wd2010_default_init(ctx, fp, drivenum, secsz, spt, heads);
 	}
 
+	if (result != WD2010_ERR_OK) return result;
+
 	drivenum = drivenum ? 1 : 0;	// force to 1 or 0
-	printf("WD2010 initialised: %d cylinders, %d heads, %d sectors per track\n",
+	printf("Drive %d initialised: %d cylinders, %d heads, %d sectors per track\n", drivenum,
 			ctx->geometry[drivenum].tracks, ctx->geometry[drivenum].heads,
 			ctx->geometry[drivenum].spt);
 


### PR DESCRIPTION
Hi @philpem and @arnoldrobbins - I tweaked the error handling / messaging on the drive image loading as I noticed there was still a hard coded drive image filename or two in the msging. I also renamed the hd image files in the sample toml to match the defaults used in code. I changed `discim` to `floppy.img` to be consistent with the hd.img and hd2.img file naming -- plus it also had seemed to confuse the user in issue #37. If someone uses the `dd` method to create a new hd.img, I updated the `default_init()` to 17 sec/trk so that the number of cylinders is calculated correctly. Currently we had a mismatch in the README `dd` instructions versus the code default which was 16 sec/trk and 8 heads.

In the README I added a note about using pre-loaded HD images from Arnold or David Gesswein -- I think that's a great way for new users to get up and going without going through the whole floppy disc install process.

Oh and Arnold, I changed your reference in the man from 1987 to 1985 -- as that sounds even more impressive for the UNIX PC!