### PR TITLE
Make more stuff configurable.

### DIFF
--- a/sample.freebee.toml
+++ b/sample.freebee.toml
@@ -10,6 +10,10 @@
 [hard_disk]
 	disk1 = "/path/to/hd.img"
 	disk2 = "/path/to/hd2.img"	# Second disk is optional
+	# Default disk parameters. Overridden by disk label in
+	# the hard disk image.
+	cylinders = 8
+	sectors_per_track = 17
 
 [display]
 	x_scale = 1.0			# Scale in X dimension, 0 < n <= 45
@@ -24,3 +28,10 @@
 
 [serial]
 	symlink = "serial-pty"
+
+[vidpal]
+	installed = true
+
+[memory]
+	base_memory = 2048		# Units of 1K bytes, 2048 is the max.
+	extended_memory = 2048		# Units of 1K bytes, 2048 is the max.

--- a/sample.freebee.toml
+++ b/sample.freebee.toml
@@ -12,7 +12,7 @@
 	disk2 = "/path/to/hd2.img"	# Second disk is optional
 	# Default disk parameters. Overridden by disk label in
 	# the hard disk image.
-	cylinders = 8
+	heads = 8
 	sectors_per_track = 17
 
 [display]

--- a/src/fbconfig.c
+++ b/src/fbconfig.c
@@ -141,7 +141,7 @@ get_default_int(const char *heading, const char *item)
 		{ "display", "red", 0x00 },
 		{ "display", "green", 0xFF },
 		{ "display", "blue", 0x00 },
-		{ "hard_disk", "cylinders", 8 },
+		{ "hard_disk", "heads", 8 },
 		{ "hard_disk", "sectors_per_track", 17 },
 		{ "memory", "base_memory", 2048 },
 		{ "memory", "extended_memory", 2048 },

--- a/src/fbconfig.c
+++ b/src/fbconfig.c
@@ -125,7 +125,7 @@ get_default_bool(const char *heading, const char *item)
 		}
 	}
 
-	return 0;
+	return false;
 }
 
 /* get_default_int --- get an int value from the configuration */

--- a/src/fbconfig.c
+++ b/src/fbconfig.c
@@ -104,7 +104,31 @@ get_default_double(const char *heading, const char *item)
 	return 0.0;
 }
 
-/* get_default_int --- get a int value from the configuration */
+/* get_default_bool --- get a bool value from the configuration */
+
+static bool
+get_default_bool(const char *heading, const char *item)
+{
+	static struct default_doubles {
+		const char *heading;
+		const char *item;
+		bool value;
+	} defaults[] = {
+		{ "vidpal", "installed", true },
+		{ NULL, NULL, false }
+	};
+
+	int i;
+	for (i = 0; defaults[i].heading != NULL; i++) {
+		if (strcmp(defaults[i].heading, heading) == 0 && strcmp(defaults[i].item, item) == 0) {
+			return defaults[i].value;
+		}
+	}
+
+	return 0;
+}
+
+/* get_default_int --- get an int value from the configuration */
 
 static int
 get_default_int(const char *heading, const char *item)
@@ -117,6 +141,10 @@ get_default_int(const char *heading, const char *item)
 		{ "display", "red", 0x00 },
 		{ "display", "green", 0xFF },
 		{ "display", "blue", 0x00 },
+		{ "hard_disk", "cylinders", 8 },
+		{ "hard_disk", "sectors_per_track", 17 },
+		{ "memory", "base_memory", 2048 },
+		{ "memory", "extended_memory", 2048 },
 		{ NULL, NULL, 0 }
 	};
 
@@ -183,7 +211,18 @@ fbc_get_bool(const char *heading, const char *item)
 	if (! inited)
 		initialize();
 
-	return false;	// no bools defined at the moment
+	if (have_toml) {
+		toml_table_t* category = toml_table_in(table_config, heading);
+		if (category != NULL) {
+			toml_datum_t value = toml_bool_in(category, item);
+			if (value.ok) {
+				return value.u.b;
+			}
+		}
+	}
+
+
+	return get_default_bool(heading, item);
 }
 
 /* fbc_get_int --- get a int value from the configuration */

--- a/src/main.c
+++ b/src/main.c
@@ -331,13 +331,13 @@ void validate_memory(int base_memory, int extended_memory)
 	}
 
 	if (! base_ok) {
-		fprintf(stderr, "base_memory size %dK is invalid\n",
+		fprintf(stderr, "Motherboard memory size %dK is invalid; it must be a multiple of 512K.\n",
 				base_memory);
 		exit(EXIT_FAILURE);
 	}
 
 	if (! extended_ok) {
-		fprintf(stderr, "extended_memory size %dK is invalid\n",
+		fprintf(stderr, "Extension memory size %dK is invalid; it must be a multiple of 512K.\n",
 				extended_memory);
 		exit(EXIT_FAILURE);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -51,6 +51,11 @@ static int load_hd()
 	int ret = 0;
 	const char *disk1 = fbc_get_string("hard_disk", "disk1");
 	const char *disk2 = fbc_get_string("hard_disk", "disk2");
+	int sectors_per_track = fbc_get_int("hard_disk", "sectors_per_track");
+	int cylinders = fbc_get_int("hard_disk", "cylinders");
+	// bytes per sector is fixed at 512, not configurable, all hard drives of the 3B1
+	// era used 512-byte sectors.
+	const int bytes_per_sector = 512;
 
 	state.hdc_disc0 = fopen(disk1, "r+b");
 	if (!state.hdc_disc0){
@@ -58,7 +63,7 @@ static int load_hd()
 		state.hdc_disc0 = NULL;
 		return (0);
 	} else {
-		if (wd2010_init(&state.hdc_ctx, state.hdc_disc0, 0, 512, 17, 8) == WD2010_ERR_OK) {
+		if (wd2010_init(&state.hdc_ctx, state.hdc_disc0, 0, bytes_per_sector, sectors_per_track, cylinders) == WD2010_ERR_OK) {
 			printf("Drive 0: Disc image '%s' loaded.\n", disk1);
 			ret = 1;
 		} else {
@@ -72,7 +77,7 @@ static int load_hd()
 		fprintf(stderr, "Drive 1: ERROR loading disc image '%s'.\n", disk2);
 		state.hdc_disc1 = NULL;
 	} else {
-		if (wd2010_init(&state.hdc_ctx, state.hdc_disc1, 1, 512, 17, 8) == WD2010_ERR_OK) {
+		if (wd2010_init(&state.hdc_ctx, state.hdc_disc1, 1, bytes_per_sector, sectors_per_track, cylinders) == WD2010_ERR_OK) {
 			printf("Drive 1: Disc image '%s' loaded.\n", disk2);
 		} else {
 			fprintf(stderr, "Drive 1: ERROR loading disc image '%s'.\n", disk2);
@@ -317,9 +322,13 @@ int main(int argc, char *argv[])
 	printf("\n");
 
 	// set up system state
-	// 512K of RAM
+	// RAM sizes come from config, default 2 Meg for each kind of memory
 	int i;
-	if ((i = state_init(2048*1024, 2048*1024)) != STATE_E_OK) {
+	int base_memory = fbc_get_int("memory", "base_memory");
+	int extended_memory = fbc_get_int("memory", "extended_memory");
+	base_memory *= 1024;
+	extended_memory *= 1024;
+	if ((i = state_init(base_memory, extended_memory)) != STATE_E_OK) {
 		fprintf(stderr, "ERROR: Emulator initialisation failed. Error code %d.\n", i);
 		return i;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -52,7 +52,7 @@ static int load_hd()
 	const char *disk1 = fbc_get_string("hard_disk", "disk1");
 	const char *disk2 = fbc_get_string("hard_disk", "disk2");
 	int sectors_per_track = fbc_get_int("hard_disk", "sectors_per_track");
-	int cylinders = fbc_get_int("hard_disk", "cylinders");
+	int heads = fbc_get_int("hard_disk", "heads");
 	// bytes per sector is fixed at 512, not configurable, all hard drives of the 3B1
 	// era used 512-byte sectors.
 	const int bytes_per_sector = 512;
@@ -63,7 +63,7 @@ static int load_hd()
 		state.hdc_disc0 = NULL;
 		return (0);
 	} else {
-		if (wd2010_init(&state.hdc_ctx, state.hdc_disc0, 0, bytes_per_sector, sectors_per_track, cylinders) == WD2010_ERR_OK) {
+		if (wd2010_init(&state.hdc_ctx, state.hdc_disc0, 0, bytes_per_sector, sectors_per_track, heads) == WD2010_ERR_OK) {
 			printf("Drive 0: Disc image '%s' loaded.\n", disk1);
 			ret = 1;
 		} else {
@@ -77,7 +77,7 @@ static int load_hd()
 		fprintf(stderr, "Drive 1: ERROR loading disc image '%s'.\n", disk2);
 		state.hdc_disc1 = NULL;
 	} else {
-		if (wd2010_init(&state.hdc_ctx, state.hdc_disc1, 1, bytes_per_sector, sectors_per_track, cylinders) == WD2010_ERR_OK) {
+		if (wd2010_init(&state.hdc_ctx, state.hdc_disc1, 1, bytes_per_sector, sectors_per_track, heads) == WD2010_ERR_OK) {
 			printf("Drive 1: Disc image '%s' loaded.\n", disk2);
 		} else {
 			fprintf(stderr, "Drive 1: ERROR loading disc image '%s'.\n", disk2);
@@ -300,6 +300,49 @@ bool HandleSDLEvents(SDL_Window *window)
 	return false;
 }
 
+
+/**
+ * @brief	Validate the memory amounts requested.
+ */
+
+void validate_memory(int base_memory, int extended_memory)
+{
+	static const int memsizes_allowed[] = {
+		512, 1024, 1536, 2048
+	};
+	bool base_ok = false;
+	bool extended_ok = false;
+
+	int i;
+	int j = sizeof(memsizes_allowed) / sizeof(const int);
+
+	for (i = 0; i < j; i++) {
+		if (base_memory == memsizes_allowed[i]) {
+			 base_ok = true;
+			 break;
+		}
+	}
+
+	for (i = 0; i < j; i++) {
+		if (extended_memory == memsizes_allowed[i]) {
+			 extended_ok = true;
+			 break;
+		}
+	}
+
+	if (! base_ok) {
+		fprintf(stderr, "base_memory size %dK is invalid\n",
+				base_memory);
+		exit(EXIT_FAILURE);
+	}
+
+	if (! extended_ok) {
+		fprintf(stderr, "extended_memory size %dK is invalid\n",
+				extended_memory);
+		exit(EXIT_FAILURE);
+	}
+}
+
 /****************************
  * blessed be thy main()...
  ****************************/
@@ -326,6 +369,9 @@ int main(int argc, char *argv[])
 	int i;
 	int base_memory = fbc_get_int("memory", "base_memory");
 	int extended_memory = fbc_get_int("memory", "extended_memory");
+
+	validate_memory(base_memory, extended_memory);	// exits if problem
+
 	base_memory *= 1024;
 	extended_memory *= 1024;
 	if ((i = state_init(base_memory, extended_memory)) != STATE_E_OK) {

--- a/src/state.c
+++ b/src/state.c
@@ -30,8 +30,8 @@ int state_init(size_t base_ram_size, size_t exp_ram_size)
 	state.dma_dev = DMA_DEV_UNDEF;
 	state.mcr2mirror = 0;
 
-	// Enable VIDPAL mod (allows user writing to VRAM)
-	state.vidpal = true;
+	// Enable VIDPAL mod (allows user writing to VRAM), per config setting
+	state.vidpal = fbc_get_bool("vidpal", "installed");
 
 	// Allocate Base RAM, making sure the user has specified a valid RAM amount first
 	// Basically: 512KiB minimum, 2MiB maximum, in increments of 512KiB.


### PR DESCRIPTION
Amount of base memory and extension memory, vidpal installed or not, default sectors per track and default number of cylinders in a disk can now be configured from `.freebee.toml`.