### PR TITLE
fix for base and extended memory config options, SDL smooth scaling, a few optimizations and clarifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,8 +223,8 @@ endif
 # Build-type specific configuration
 ####
 ifeq ($(BUILD_TYPE),debug)
-	CFLAGS		+= -O -g -ggdb -DDEBUG
-	CXXFLAGS	+= -O -g -ggdb -DDEBUG
+	CFLAGS		+= -g -ggdb -DDEBUG
+	CXXFLAGS	+= -g -ggdb -DDEBUG
 else
  ifeq ($(BUILD_TYPE),release)
 	CFLAGS		+= -O2

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ VER_EXTRA	?=
 # build platform: win32 or linux
 PLATFORM	?=	linux
 # build type: release or debug
-BUILD_TYPE	?=	debug
+BUILD_TYPE	?=	release
 
 # target executable
 TARGET		=	freebee
@@ -166,8 +166,8 @@ endif
 ####
 CC		=	gcc
 CXX		=	g++
-CFLAGS	=	-O -Wall -pedantic -std=gnu99 $(EXT_CFLAGS)
-CXXFLAGS=	-O -Wall -pedantic -std=gnu++0x $(EXT_CXXFLAGS)
+CFLAGS	=	-Wall -pedantic -std=gnu99 $(EXT_CFLAGS)
+CXXFLAGS=	-Wall -pedantic -std=gnu++0x $(EXT_CXXFLAGS)
 LDFLAGS	=	$(EXT_LDFLAGS)
 RM		=	rm
 STRIP	=	strip
@@ -223,8 +223,8 @@ endif
 # Build-type specific configuration
 ####
 ifeq ($(BUILD_TYPE),debug)
-	CFLAGS		+= -g -ggdb -DDEBUG
-	CXXFLAGS	+= -g -ggdb -DDEBUG
+	CFLAGS		+= -O -g -ggdb -DDEBUG
+	CXXFLAGS	+= -O -g -ggdb -DDEBUG
 else
  ifeq ($(BUILD_TYPE),release)
 	CFLAGS		+= -O2

--- a/sample.freebee.toml
+++ b/sample.freebee.toml
@@ -18,6 +18,7 @@
 [display]
 	x_scale = 1.0			# Scale in X dimension, 0 < n <= 45
 	y_scale = 1.0			# Scale in Y dimension, 0 < n <= 45
+	scale_quality = "nearest"	# "nearest" (default), "linear", or "best"
 	red = 0x00			# foreground colors
 	green = 0xFF
 	blue = 0x00

--- a/sample.freebee.toml
+++ b/sample.freebee.toml
@@ -18,7 +18,7 @@
 [display]
 	x_scale = 1.0			# Scale in X dimension, 0 < n <= 45
 	y_scale = 1.0			# Scale in Y dimension, 0 < n <= 45
-	scale_quality = "nearest"	# "nearest" (default), "linear", or "best"
+	scale_quality = "linear"	# "nearest" (fastest), "linear" (default), or "best" (anisotropic)
 	red = 0x00			# foreground colors
 	green = 0xFF
 	blue = 0x00

--- a/src/fbconfig.c
+++ b/src/fbconfig.c
@@ -66,6 +66,7 @@ get_default_string(const char *heading, const char *item)
 		{ "roms", "rom_14c", "roms/14c.bin" },
 		{ "roms", "rom_15c", "roms/15c.bin" },
 		{ "serial", "symlink", "serial-pty" },
+		{ "display", "scale_quality", "nearest" },
 		{ NULL, NULL, NULL }
 	};
 

--- a/src/fbconfig.c
+++ b/src/fbconfig.c
@@ -66,7 +66,7 @@ get_default_string(const char *heading, const char *item)
 		{ "roms", "rom_14c", "roms/14c.bin" },
 		{ "roms", "rom_15c", "roms/15c.bin" },
 		{ "serial", "symlink", "serial-pty" },
-		{ "display", "scale_quality", "nearest" },
+		{ "display", "scale_quality", "linear" },
 		{ NULL, NULL, NULL }
 	};
 

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -94,8 +94,8 @@ struct {
 	{ SDLK_KP_5,			0,	0x4a },	// Home			[Keypad 5]
 	{ SDLK_END,				0,	0x4b },	// End
 	{ SDLK_KP_6,			0,	0x4b },	// End			[Keypad 6]
-	{ SDLK_LCTRL,			0,	0x4c },	// Left Ctrl?	\___ not sure which is left and which is right...
-	{ SDLK_RCTRL,			0,	0x4d },	// Right Ctrl?	/
+	{ SDLK_LCTRL,			0,	0x4c },	// Left Ctrl
+	{ SDLK_RCTRL,			0,	0x4d },	// Right Ctrl
 // Keycodes 4E thru 5A not used
 	{ SDLK_LEFTBRACKET,		0,	0x5b },	// [
 	{ SDLK_BACKSLASH,		0,	0x5c },	// \ (backslash)

--- a/src/main.c
+++ b/src/main.c
@@ -97,7 +97,7 @@ static int load_hd()
  * @param	y			Y co-ordinate
  * @param	pixel		Pixel value (from SDL_MapRGB)
  */
-void putpixel(SDL_Surface *surface, int x, int y, Uint32 pixel)
+static inline void putpixel(SDL_Surface *surface, int x, int y, Uint32 pixel)
 {
 	int bpp = surface->format->BytesPerPixel;
 	/* Here p is the address to the pixel we want to set */

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include "state.h"
 #include "memory.h"
 #include "fbconfig.h"
+#include "utils.h"
 
 #include "lightbar.c"
 #include "i8274.h"
@@ -307,31 +308,34 @@ bool HandleSDLEvents(SDL_Window *window)
 
 void validate_memory(int base_memory, int extended_memory)
 {
-	static const int memsizes_allowed[] = {
-		512, 1024, 1536, 2048
+	static const int base_memsizes_allowed[] = {
+		512, 1024, 2048
 	};
+	static const int extended_memsizes_allowed[] = {
+		0, 512, 1024, 1536, 2048
+	};
+
 	bool base_ok = false;
 	bool extended_ok = false;
 
 	int i;
-	int j = sizeof(memsizes_allowed) / sizeof(const int);
 
-	for (i = 0; i < j; i++) {
-		if (base_memory == memsizes_allowed[i]) {
+	for (i = 0; i < NELEMS(base_memsizes_allowed); i++) {
+		if (base_memory == base_memsizes_allowed[i]) {
 			 base_ok = true;
 			 break;
 		}
 	}
 
-	for (i = 0; i < j; i++) {
-		if (extended_memory == memsizes_allowed[i]) {
+	for (i = 0; i < NELEMS(extended_memsizes_allowed); i++) {
+		if (extended_memory == extended_memsizes_allowed[i]) {
 			 extended_ok = true;
 			 break;
 		}
 	}
 
 	if (! base_ok) {
-		fprintf(stderr, "Motherboard memory size %dK is invalid; it must be a multiple of 512K.\n",
+		fprintf(stderr, "Motherboard memory size %dK is invalid; it must be 512, 1024, or 2048.\n",
 				base_memory);
 		exit(EXIT_FAILURE);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -404,7 +404,9 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "Error creating SDL window: %s.\n", SDL_GetError());
 		exit(EXIT_FAILURE);
 	}
-	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, fbc_get_string("display", "scale_quality"));  // "nearest" (default), "linear", or "best"
+    // SDL default is "nearest", our default is "linear" if there's scaling
+    if (scalex != 1.0 || scaley != 1.0)
+	    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, fbc_get_string("display", "scale_quality"));
 	SDL_Renderer *renderer = SDL_CreateRenderer(window, -1, 0);
 	SDL_RenderSetScale(renderer, scalex, scaley);
 	if (!renderer){

--- a/src/main.c
+++ b/src/main.c
@@ -400,6 +400,7 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "Error creating SDL window: %s.\n", SDL_GetError());
 		exit(EXIT_FAILURE);
 	}
+	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, fbc_get_string("display", "scale_quality"));  // "nearest" (default), "linear", or "best"
 	SDL_Renderer *renderer = SDL_CreateRenderer(window, -1, 0);
 	SDL_RenderSetScale(renderer, scalex, scaley);
 	if (!renderer){

--- a/src/main.c
+++ b/src/main.c
@@ -345,6 +345,10 @@ void validate_memory(int base_memory, int extended_memory)
 				extended_memory);
 		exit(EXIT_FAILURE);
 	}
+
+    printf("Memory config: %iKB On-board, %iKB Expansion\n", base_memory, extended_memory);
+    if (base_memory + extended_memory < 1024)
+       printf("*WARNING*: UNIX 3.51 requires 1MB of RAM. This configuration will only boot UNIX 3.50.\n\n");
 }
 
 /****************************

--- a/src/main.c
+++ b/src/main.c
@@ -474,7 +474,7 @@ int main(int argc, char *argv[])
 					uint16_t d = 0;
 
 					// num tells us how many words we've copied. If this is greater than the per-timeslot DMA maximum, bail out!
-					if (num > (1e6/TIMESLOT_FREQUENCY)) break;
+					if (num > (1e6/TIMESLOT_FREQUENCY / NUM_CPU_TIMESLOTS)) break;
 
 					// Evidently we have more words to copy. Copy them.
 					if (state.dma_dev == DMA_DEV_FD){

--- a/src/main.c
+++ b/src/main.c
@@ -450,21 +450,22 @@ int main(int argc, char *argv[])
 	const uint32_t SYSTEM_CLOCK = 10e6; // Hz
 	const uint32_t TIMESLOT_FREQUENCY = 100;//240;	// Hz
 	const uint32_t MILLISECS_PER_TIMESLOT = 1e3 / TIMESLOT_FREQUENCY;
+	const uint32_t CYCLES_PER_TIMESLOT = SYSTEM_CLOCK / TIMESLOT_FREQUENCY;
 	const uint32_t CLOCKS_PER_60HZ = (SYSTEM_CLOCK / 60);
 	const uint32_t NUM_CPU_TIMESLOTS = 500;
 	uint32_t next_timeslot = SDL_GetTicks() + MILLISECS_PER_TIMESLOT;
-	uint32_t clock_cycles = 0, tmp;
+	uint32_t clock_cycles = 0, cycles_run;
 	bool exitEmu = false;
 	uint8_t last_leds = 255;
 
 	/*bool lastirq_fdc = false;*/
 	for (;;) {
-		for (i = 0; i < NUM_CPU_TIMESLOTS; i++){
+		for (i = 0; i < CYCLES_PER_TIMESLOT; i += cycles_run){
 			// Run the CPU for however many cycles we need to. CPU core clock is
 			// 10MHz, and we're running at 240Hz/timeslot. Thus: 10e6/240 or
 			// 41667 cycles per timeslot.
-			tmp = m68k_execute(SYSTEM_CLOCK/TIMESLOT_FREQUENCY / NUM_CPU_TIMESLOTS);
-			clock_cycles += tmp;
+			cycles_run = m68k_execute(CYCLES_PER_TIMESLOT / NUM_CPU_TIMESLOTS);
+			clock_cycles += cycles_run;
 
 			// Run the DMA engine
 			if (state.dmaen) {

--- a/src/memory.c
+++ b/src/memory.c
@@ -1098,9 +1098,7 @@ uint32_t m68k_read_memory_8(uint32_t address)/*{{{*/
 
 static void ram_write_16(uint32_t address, uint32_t value)/*{{{*/
 {
-	if (address < ZEROPAGE && USER_MODE) {
-		return;
-	} else if (address <= 0x1fffff) {
+	if (address <= 0x1fffff) {
 		if (address < state.base_ram_size) {
 			WR16(state.base_ram, address, state.base_ram_size - 1, value);
 		}
@@ -1166,9 +1164,7 @@ void m68k_write_memory_16(uint32_t address, uint32_t value)/*{{{*/
 	// Check access permissions
 	ACCESS_CHECK_WR(address, 16);
 
-	if (address < ZEROPAGE && USER_MODE) {
-		return;
-	} else if ((address >= 0x800000) && (address <= 0xBFFFFF)) {
+	if ((address >= 0x800000) && (address <= 0xBFFFFF)) {
 		// ROM access
 	} else if (address <= 0x3FFFFF) {
 		// RAM access
@@ -1215,9 +1211,7 @@ void m68k_write_memory_8(uint32_t address, uint32_t value)/*{{{*/
 	// Check access permissions
 	ACCESS_CHECK_WR(address, 8);
 
-	if (address < ZEROPAGE && USER_MODE) {
-		return;
-	} else if ((address >= 0x800000) && (address <= 0xBFFFFF)) {
+	if ((address >= 0x800000) && (address <= 0xBFFFFF)) {
 		// ROM access (read only!)
 	} else if (address <= 0x3FFFFF) {
 		// RAM access

--- a/src/memory.c
+++ b/src/memory.c
@@ -1040,6 +1040,12 @@ uint32_t m68k_read_memory_8(uint32_t address)/*{{{*/
 {
 	uint8_t data = EMPTY & 0xFF;
 
+	// Musashi m68ki_exception_bus_error() check
+	// If this read occurs, pulse_bus_error() was called when we were already processing
+	//   a bus error, address error, or reset, this is a catastrophic failure
+	// This occurs during Diagnostics:Processor:Page Protection Tests #2 (12,2) and #4 (12,4)
+	assert(address != 0xFFFF01);
+
 	// If ROMLMAP is set, force system to access ROM
 	if (!state.romlmap)
 		address |= 0x800000;

--- a/src/memory.c
+++ b/src/memory.c
@@ -515,8 +515,11 @@ void IoWrite(uint32_t address, uint32_t data, int bits)/*{{{*/
 				break;
 			case 0x0C0000:				// Clear Status Register
 				// CSR is used to clear PERR* (main memory parity error), which is currently always returned as 'no parity error'
+				// "If the current cycle causes a parity error, MMU error, or processor bus error, GSR is not updated at the following cycles until CSR"
 				// clear MMU error in BSR0
 				state.bsr0 |= 0x8000;
+				// also disable PF- and UIE- in GSR
+				state.genstat |= 0x1100;
 				handled = true;
 				break;
 			case 0x0D0000:				// DMA Address Register

--- a/src/memory.c
+++ b/src/memory.c
@@ -40,7 +40,7 @@
  * Memory mapping
  ******************/
 
-#define MAPRAM(addr) (((uint16_t)state.map[addr*2] << 8) + ((uint16_t)state.map[(addr*2)+1]))
+#define MAPRAM(page) (((uint16_t)state.map[page*2] << 8) + ((uint16_t)state.map[(page*2)+1]))
 
 static uint32_t map_address_debug(uint32_t addr)
 {
@@ -53,52 +53,50 @@ static uint32_t map_address_debug(uint32_t addr)
 
 uint32_t mapAddr(uint32_t addr, bool writing)/*{{{*/
 {
-	if (addr < 0x400000) {
-		// RAM access. Check against the Map RAM
-		// Start by getting the original page address
-		uint16_t page = (addr >> 12) & 0x3FF;
+	assert(addr < 0x400000);
 
-		// Look it up in the map RAM and get the physical page address
-		uint32_t new_page_addr = MAPRAM(page) & 0x3FF;
+	// RAM access. Check against the Map RAM
+	// Start by getting the original page address
+	uint16_t page = (addr >> 12) & 0x3FF;
 
-		// Update the Page Status bits
-		uint8_t pagebits = (MAPRAM(page) >> 13) & 0x03;
-		// Pagebits --
-		//   0 = not present
-		//   1 = present but not accessed
-		//   2 = present, accessed (read from)
-		//   3 = present, dirty (written to)
-		switch (pagebits) {
-			case 0:
-				// Page not present
-				// This should cause a page fault
-				LOGS("Whoa! Pagebit update, when the page is not present!");
-				break;
+	// Look it up in the map RAM and get the physical page
+	uint32_t new_page = MAPRAM(page) & 0x3FF;
 
-			case 1:
-				// Page present -- first access
-				state.map[page*2] &= 0x9F;	// turn off "present" bit (but not write enable!)
-				if (writing)
-					state.map[page*2] |= 0x60;		// Page written to (dirty)
-				else
-					state.map[page*2] |= 0x40;		// Page accessed but not written
-				break;
+	// Update the Page Status bits
+	uint8_t pagebits = (state.map[page*2] >> 5) & 0x03;
+	// Pagebits --
+	//   0 = not present
+	//   1 = present but not accessed
+	//   2 = present, accessed (read from)
+	//   3 = present, dirty (written to)
+	switch (pagebits) {
+		case 0:
+			// Page not present
+			// This should cause a page fault
+			LOGS("Whoa! Pagebit update, when the page is not present!");
+			break;
 
-			case 2:
-			case 3:
-				// Page present, 2nd or later access
-				if (writing)
-					state.map[page*2] |= 0x60;		// Page written to (dirty)
-				break;
-		}
+		case 1:
+			// Page present -- first access
+			state.map[page*2] &= 0x9F;	// turn off "present" bit (but not write enable!)
+			if (writing)
+				state.map[page*2] |= 0x60;		// Page written to (dirty)
+			else
+				state.map[page*2] |= 0x40;		// Page accessed but not written
+			break;
 
-		// Return the address with the new physical page spliced in
-		return (new_page_addr << 12) + (addr & 0xFFF);
-	} else {
-		// I/O, VRAM or MapRAM space; no mapping is performed or required
-		// TODO: assert here?
-		return addr;
+		case 2:
+			// Page present, 2nd or later access
+			if (writing)
+				state.map[page*2] |= 0x60;		// Page written to (dirty)
+			break;
+		case 3:
+			// Page already dirty, no change
+			break;
 	}
+
+	// Return the address with the new physical page spliced in
+	return (new_page << 12) + (addr & 0xFFF);
 }/*}}}*/
 
 MEM_STATUS checkMemoryAccess(uint32_t addr, bool writing, bool dma)/*{{{*/
@@ -109,7 +107,8 @@ MEM_STATUS checkMemoryAccess(uint32_t addr, bool writing, bool dma)/*{{{*/
 
 	// Check page is present (but only for RAM zone)
 	if ((addr < 0x400000) && ((pagebits & 0x03) == 0)) {
-		LOG_PF("Page fault: addr 0x%06X, page %04X, mapbits %04X", addr, page, MAPRAM(page));
+		LOG_PF("Page fault: addr 0x%06X, page %03X -> phys page %03X, pagebits %d",
+				addr, page, MAPRAM(page) & 0x3FF, pagebits);
 		return MEM_PAGEFAULT;
 	}
 
@@ -132,15 +131,15 @@ MEM_STATUS checkMemoryAccess(uint32_t addr, bool writing, bool dma)/*{{{*/
 
 	// User attempt to access the kernel
 	// A19, A20, A21, A22 low (kernel access): RAM addr before paging; not in Supervisor mode
-	if (((addr >> 19) & 0x0F) == 0 && !(!writing && addr < ZEROPAGE)) {
+	if (addr < 0x080000 && !(!writing && addr < ZEROPAGE)) {
 		LOGS("Attempt by user code to access kernel space");
 		return MEM_KERNEL;
 	}
 
 	// Check page is write enabled
 	if (writing && ((pagebits & 0x04) == 0)) {
-		LOG_PF("Page not write enabled: inaddr 0x%06X, page %04X, mapram %04X [%02X %02X], pagebits %d",
-				addr, page, MAPRAM(page), state.map[page*2], state.map[(page*2)+1], pagebits);
+		LOG_PF("Page not write enabled: addr 0x%06X, page %03X -> phys page %03X, pagebits %d",
+				addr, page, MAPRAM(page) & 0x3FF, pagebits);
 		return MEM_PAGE_NO_WE;
 	}
 	// Page access allowed.
@@ -300,7 +299,8 @@ bool access_check_dma(int reading)
 
 		case MEM_UIE:
 			// User access to memory above 4MB
-			// FIXME? Shouldn't be possible with DMA... assert this?
+			// Shouldn't be possible with DMA, assert this
+			assert(0);
 			state.genstat = 0x30FF
 				| (reading ? 0x4000 : 0)
 				| (state.pie ? 0x8400 : 0);
@@ -310,7 +310,8 @@ bool access_check_dma(int reading)
 		case MEM_KERNEL:
 		case MEM_PAGE_NO_WE:
 			// Kernel access or page not write enabled
-			/* XXX: is this correct? */
+			// Shouldn't be possible with DMA, assert this
+			assert(0);
 			state.genstat = 0x31FF
 				| (reading ? 0x4000 : 0)
 				| (state.pie ? 0x8400 : 0);
@@ -325,8 +326,9 @@ bool access_check_dma(int reading)
 		state.bsr0 = 0x3C00;
 		state.bsr0 |= (state.dma_address >> 16);
 		state.bsr1 = state.dma_address & 0xffff;
+		// trigger NMI (DMA Page Fault) kernel panic
 		if (state.ee) m68k_set_irq(7);
-		printf("BUS ERROR FROM DMA: genstat=%04X, bsr0=%04X, bsr1=%04X\n", state.genstat, state.bsr0, state.bsr1);
+		printf("DMA PAGE FAULT: genstat=%04X, bsr0=%04X, bsr1=%04X\n", state.genstat, state.bsr0, state.bsr1);
 	}
 	return (access_ok);
 }

--- a/src/memory.c
+++ b/src/memory.c
@@ -207,6 +207,7 @@ MEM_STATUS checkMemoryAccess(uint32_t addr, bool writing, bool dma)/*{{{*/
 				state.bsr0 = 0x7C00;								\
 			else													\
 				state.bsr0 = (faultAddr & 1) ? 0x7E00 : 0x7D00;		\
+			if (st==MEM_UIE) state.bsr0 |= 0x8000; 					\
 			state.bsr0 |= (faultAddr >> 16);							\
 			state.bsr1 = faultAddr & 0xffff;							\
 			LOG_PF("Bus Error while writing, addr %08X, statcode %d", address, st);		\
@@ -271,6 +272,7 @@ MEM_STATUS checkMemoryAccess(uint32_t addr, bool writing, bool dma)/*{{{*/
 				state.bsr0 = 0x7C00;								\
 			else													\
 				state.bsr0 = (faultAddr & 1) ? 0x7E00 : 0x7D00;		\
+			if (st==MEM_UIE) state.bsr0 |= 0x8000;					\
 			state.bsr0 |= (faultAddr >> 16);							\
 			state.bsr1 = faultAddr & 0xffff;							\
 			LOG_PF("Bus Error while reading, addr %08X, statcode %d", faultAddr, st);		\

--- a/src/state.c
+++ b/src/state.c
@@ -19,7 +19,7 @@ int state_init(size_t base_ram_size, size_t exp_ram_size)
 
 	// Initialise hardware registers
 	state.romlmap = false;
-	state.idmarw = state.dmaen = state.dmaenb = false;
+	state.idmarw = state.dmaen = false;
 	state.dma_count = state.dma_address = 0;
 	state.pie = 0;
 	state.ee = 0;

--- a/src/state.h
+++ b/src/state.h
@@ -80,7 +80,6 @@ typedef struct {
 	bool		idmarw;
 	/// DMA enable
 	bool		dmaen;
-	bool		dmaenb;
 
 	/// DMA device selection flags
 	bool		fd_selected;


### PR DESCRIPTION
Hi @philpem - here are a few things I've been working on recently. I noticed in testing the memory config options that @arnoldrobbins added, that 1536K for base memory was not a supported configuration by the OS so I removed it as a valid option. And also added 0K as a valid option for the extended memory config. 

In testing with 512K and no extended memory, I did run into the system crashing (during "loading drivers" or "setting up screen") and not being able to successfully boot. I will open an Issue for this. It did trigger a strange read_memory_8 to 0xFFFF01 which I tracked back to Musashi. This strange case also occurs when running Page Protection test 12,2 (user kernel space [< 0x080000] access) and 12,4 (DMA page fault). Successive reads will eventually crash the emulator so I assert if this is encountered. The Musashi read to FFFF01 occurs when a bus error is triggered within servicing a bus error which shouldn't happen.

I also noticed the DMA engine was allowed to run faster than it should in main so fixed that. This may slow down the system but I believe is more "hardware correct".

I added a scale_quality option which is sent to SDL so you can get smooth scaling. This is useful to set to "best" when using a non-integer scale ratio, for example I use y_scale = 1.55 to get a 4:3 aspect ratio. 

I also did some profiling with valgrind, and attempted to speed up checkMemoryAccess as that and mapAddr are called millions of times. Mainly trying to avoid the check to SUPERVISOR_MODE. Also removed zero page write checks (which also checked for SUPERVISOR_MODE) as they aren't needed because checkMemoryAccess already catches any write attempts to zero page as a MEM_KERNEL error.   And inline'd putpixel that's in main.

Also a minor tweak on disabling PF- and UIE- in CSR (clear status reg) that I don't believe changes any behavior of the emulator but seemed correct to do on CSR being called.

Shall we change default BUILD_TYPE in the Makefile to `release`?

   Jesse