### PR TITLE
Latest Musashi with fix to allow bus error within a bus error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,9 @@ src/musashi/m68kopnz.c
 src/musashi/m68kops.c
 src/musashi/m68kops.h
 dep/musashi/*.d
+dep/musashi/softfloat/*.d
 obj/musashi/*.o
+obj/musashi/softfloat/*.o
 obj/musashi/m68kmake
 
 # version header

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,12 @@ roms
 TRM
 misc
 discs
+
+# config file
+.freebee.toml
+
+# disc images
+*.img
+
+# serial port pty link
+serial-pty

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,18 @@ else
 endif
 
 ####
+# Musashi config file
+####
+ifeq ($(PLATFORM),linux)
+	CFLAGS		+= -DMUSASHI_CNF=\"../m68kconf.h\"
+	CXXFLAGS	+= -DMUSASHI_CNF=\"../m68kconf.h\"
+endif
+ifeq ($(PLATFORM),win32)
+	CFLAGS		+= -DMUSASHI_CNF="../m68kconf.h"
+	CXXFLAGS	+= -DMUSASHI_CNF="../m68kconf.h"
+endif
+
+####
 # wxWidgets support
 ####
 ifeq ($(ENABLE_WX),yes)

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ TARGET		=	freebee
 
 # source files that produce object files
 SRC			=	main.c state.c memory.c wd279x.c wd2010.c keyboard.c tc8250.c diskraw.c diskimd.c i8274.c fbconfig.c toml.c
-SRC			+=	musashi/m68kcpu.c musashi/m68kdasm.c musashi/m68kops.c musashi/m68kfpu.c
+SRC			+=	musashi/m68kcpu.c musashi/m68kdasm.c musashi/m68kops.c musashi/softfloat/softfloat.c
 
 # source type - either "c" or "cpp" (C or C++)
 SRC_TYPE	=	c

--- a/dep/musashi/softfloat/.keepme
+++ b/dep/musashi/softfloat/.keepme
@@ -1,0 +1,1 @@
+This file is a directory-keeper. Do not delete it.

--- a/obj/musashi/softfloat/.keepme
+++ b/obj/musashi/softfloat/.keepme
@@ -1,0 +1,1 @@
+This file is a directory-keeper. Do not delete it.

--- a/src/m68kconf.h
+++ b/src/m68kconf.h
@@ -1,0 +1,209 @@
+/* ======================================================================== */
+/* ========================= LICENSING & COPYRIGHT ======================== */
+/* ======================================================================== */
+/*
+ *                                  MUSASHI
+ *                                Version 3.32
+ *
+ * A portable Motorola M680x0 processor emulation engine.
+ * Copyright Karl Stenerud.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+
+#ifndef M68KCONF__HEADER
+#define M68KCONF__HEADER
+
+
+/* Configuration switches.
+ * Use OPT_SPECIFY_HANDLER for configuration options that allow callbacks.
+ * OPT_SPECIFY_HANDLER causes the core to link directly to the function
+ * or macro you specify, rather than using callback functions whose pointer
+ * must be passed in using m68k_set_xxx_callback().
+ */
+#define OPT_OFF             0
+#define OPT_ON              1
+#define OPT_SPECIFY_HANDLER 2
+
+
+/* ======================================================================== */
+/* ============================== MAME STUFF ============================== */
+/* ======================================================================== */
+
+/* If you're compiling this for MAME, only change M68K_COMPILE_FOR_MAME
+ * to OPT_ON and use m68kmame.h to configure the 68k core.
+ */
+#ifndef M68K_COMPILE_FOR_MAME
+#define M68K_COMPILE_FOR_MAME      OPT_OFF
+#endif /* M68K_COMPILE_FOR_MAME */
+
+
+#if M68K_COMPILE_FOR_MAME == OPT_OFF
+
+
+/* ======================================================================== */
+/* ============================= CONFIGURATION ============================ */
+/* ======================================================================== */
+
+/* Turn ON if you want to use the following M68K variants */
+#define M68K_EMULATE_010            OPT_ON
+#define M68K_EMULATE_EC020          OPT_OFF
+#define M68K_EMULATE_020            OPT_OFF
+#define M68K_EMULATE_030            OPT_OFF
+#define M68K_EMULATE_040            OPT_OFF
+
+/* If ON, the CPU will call m68k_read_immediate_xx() for immediate addressing
+ * and m68k_read_pcrelative_xx() for PC-relative addressing.
+ * If off, all read requests from the CPU will be redirected to m68k_read_xx()
+ */
+#define M68K_SEPARATE_READS         OPT_OFF
+
+/* If ON, the CPU will call m68k_write_32_pd() when it executes move.l with a
+ * predecrement destination EA mode instead of m68k_write_32().
+ * To simulate real 68k behavior, m68k_write_32_pd() must first write the high
+ * word to [address+2], and then write the low word to [address].
+ */
+#define M68K_SIMULATE_PD_WRITES     OPT_OFF
+
+/* If ON, CPU will call the interrupt acknowledge callback when it services an
+ * interrupt.
+ * If off, all interrupts will be autovectored and all interrupt requests will
+ * auto-clear when the interrupt is serviced.
+ */
+#define M68K_EMULATE_INT_ACK        OPT_OFF
+#define M68K_INT_ACK_CALLBACK(A)    your_int_ack_handler_function(A)
+
+
+/* If ON, CPU will call the breakpoint acknowledge callback when it encounters
+ * a breakpoint instruction and it is running a 68010+.
+ */
+#define M68K_EMULATE_BKPT_ACK       OPT_OFF
+#define M68K_BKPT_ACK_CALLBACK()    your_bkpt_ack_handler_function()
+
+
+/* If ON, the CPU will monitor the trace flags and take trace exceptions
+ */
+#define M68K_EMULATE_TRACE          OPT_OFF
+
+
+/* If ON, CPU will call the output reset callback when it encounters a reset
+ * instruction.
+ */
+#define M68K_EMULATE_RESET          OPT_OFF
+#define M68K_RESET_CALLBACK()       your_reset_handler_function()
+
+/* If ON, CPU will call the callback when it encounters a cmpi.l #v, dn
+ * instruction.
+ */
+#define M68K_CMPILD_HAS_CALLBACK     OPT_OFF
+#define M68K_CMPILD_CALLBACK(v,r)    your_cmpild_handler_function(v,r)
+
+
+/* If ON, CPU will call the callback when it encounters a rte
+ * instruction.
+ */
+#define M68K_RTE_HAS_CALLBACK       OPT_OFF
+#define M68K_RTE_CALLBACK()         your_rte_handler_function()
+
+/* If ON, CPU will call the callback when it encounters a tas
+ * instruction.
+ */
+#define M68K_TAS_HAS_CALLBACK       OPT_OFF
+#define M68K_TAS_CALLBACK()         your_tas_handler_function()
+
+/* If ON, CPU will call the callback when it encounters an illegal instruction
+ * passing the opcode as argument. If the callback returns 1, then it's considered
+ * as a normal instruction, and the illegal exception in canceled. If it returns 0,
+ * the exception occurs normally.
+ * The callback looks like int callback(int opcode)
+ * You should put OPT_SPECIFY_HANDLER here if you cant to use it, otherwise it will
+ * use a dummy default handler and you'll have to call m68k_set_illg_instr_callback explicitely
+ */
+#define M68K_ILLG_HAS_CALLBACK	    OPT_OFF
+#define M68K_ILLG_CALLBACK(opcode)  op_illg(opcode)
+
+/* If ON, CPU will call the set fc callback on every memory access to
+ * differentiate between user/supervisor, program/data access like a real
+ * 68000 would.  This should be enabled and the callback should be set if you
+ * want to properly emulate the m68010 or higher. (moves uses function codes
+ * to read/write data from different address spaces)
+ */
+#define M68K_EMULATE_FC             OPT_OFF
+#define M68K_SET_FC_CALLBACK(A)     your_set_fc_handler_function(A)
+
+/* If ON, CPU will call the pc changed callback when it changes the PC by a
+ * large value.  This allows host programs to be nicer when it comes to
+ * fetching immediate data and instructions on a banked memory system.
+ */
+#define M68K_MONITOR_PC             OPT_OFF
+#define M68K_SET_PC_CALLBACK(A)     your_pc_changed_handler_function(A)
+
+
+/* If ON, CPU will call the instruction hook callback before every
+ * instruction.
+ */
+#define M68K_INSTRUCTION_HOOK       OPT_OFF
+#define M68K_INSTRUCTION_CALLBACK(pc) your_instruction_hook_function(pc)
+
+
+/* If ON, the CPU will emulate the 4-byte prefetch queue of a real 68000 */
+#define M68K_EMULATE_PREFETCH       OPT_ON
+
+
+/* If ON, the CPU will generate address error exceptions if it tries to
+ * access a word or longword at an odd address.
+ * NOTE: This is only emulated properly for 68000 mode.
+ */
+#define M68K_EMULATE_ADDRESS_ERROR  OPT_OFF
+
+
+/* Turn ON to enable logging of illegal instruction calls.
+ * M68K_LOG_FILEHANDLE must be #defined to a stdio file stream.
+ * Turn on M68K_LOG_1010_1111 to log all 1010 and 1111 calls.
+ */
+#define M68K_LOG_ENABLE             OPT_OFF
+#define M68K_LOG_1010_1111          OPT_OFF
+#define M68K_LOG_FILEHANDLE         some_file_handle
+
+/* Emulate PMMU : if you enable this, there will be a test to see if the current chip has some enabled pmmu added to every memory access,
+ * so enable this only if it's useful */
+#define M68K_EMULATE_PMMU   OPT_OFF
+
+/* ----------------------------- COMPATIBILITY ---------------------------- */
+
+/* The following options set optimizations that violate the current ANSI
+ * standard, but will be compliant under the forthcoming C9X standard.
+ */
+
+
+/* If ON, the enulation core will use 64-bit integers to speed up some
+ * operations.
+*/
+#define M68K_USE_64_BIT  OPT_ON
+
+
+#endif /* M68K_COMPILE_FOR_MAME */
+
+/* ======================================================================== */
+/* ============================== END OF FILE ============================= */
+/* ======================================================================== */
+
+#endif /* M68KCONF__HEADER */

--- a/src/main.c
+++ b/src/main.c
@@ -268,6 +268,7 @@ bool HandleSDLEvents(SDL_Window *window)
 				break;
 			case SDL_MOUSEMOTION:
 				SDL_GetRelativeMouseState(&dx, &dy);
+				if (dx==0 && dy==0) break;  // sometimes SDL returns 0 for both, don't process
 			case SDL_MOUSEBUTTONUP:
 			case SDL_MOUSEBUTTONDOWN:
 				if (mouse_grabbed){

--- a/src/main.c
+++ b/src/main.c
@@ -348,7 +348,7 @@ void validate_memory(int base_memory, int extended_memory)
 
     printf("Memory config: %iKB On-board, %iKB Expansion\n", base_memory, extended_memory);
     if (base_memory + extended_memory < 1024)
-       printf("*WARNING*: UNIX 3.51 requires 1MB of RAM. This configuration will only boot UNIX 3.50.\n\n");
+       printf("*WARNING*: 1MB or higher RAM recommended for UNIX 3.51.\n\n");
 }
 
 /****************************

--- a/src/memory.c
+++ b/src/memory.c
@@ -1056,12 +1056,6 @@ uint32_t m68k_read_memory_8(uint32_t address)/*{{{*/
 {
 	uint8_t data = EMPTY & 0xFF;
 
-	// Musashi m68ki_exception_bus_error() check
-	// If this read occurs, pulse_bus_error() was called when we were already processing
-	//   a bus error, address error, or reset, this is a catastrophic failure
-	// This occurs during Diagnostics:Processor:Page Protection Tests #2 (12,2) and #4 (12,4)
-	assert(address != 0xFFFF01);
-
 	// If ROMLMAP is set, force system to access ROM
 	if (!state.romlmap)
 		address |= 0x800000;


### PR DESCRIPTION
Hi Phil.

Karl integrated my fix for bus error within a bus error into Musashi. There were times when this would occur on the UNIX PC and Musashi choked on it because it was treating it as illegal. Which it's not. It's only during setting up the stack frame for bus error processing that a 2nd bus error can't occur. Some instances when this was occurring:
- Diagnostics:Processor:Page Protection Tests 2 (subtest 12,2) and 4 (subtest 12,4)
- Booting UNIX 3.51 with 512KB configured (I think it may have been attempting to use the swap file)

I also added a custom Musashi config file -- this disables all but the 68010 support, disables PMMU support (which makes things slower and we don't need), and enabled prefetch emulation as that seems more accurate.

Also some minor fixes to the mouse packet data (I dove into the details of that when making a ps/2 mouse to UNIX PC mouse converter).

Hope things are good with you.

   Jesse